### PR TITLE
Add release checklist and dependency monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "10:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "Tech-Debt"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "10:30"
+    open-pull-requests-limit: 5
+    labels:
+      - "Tech-Debt"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/dependency-vulnerability-check.yml
+++ b/.github/workflows/dependency-vulnerability-check.yml
@@ -1,0 +1,31 @@
+name: dependency-vulnerability-check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - v*
+  schedule:
+    - cron: "30 14 * * 6"
+  workflow_dispatch:
+
+jobs:
+  dotnet-vulnerability-check:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore PitmastersGrill\PitmastersGrill.slnx
+
+      - name: Check vulnerable packages
+        shell: pwsh
+        run: .\tools\dependencies\check-dotnet-vulnerabilities.ps1

--- a/docs/DEPENDENCY-MAINTENANCE.md
+++ b/docs/DEPENDENCY-MAINTENANCE.md
@@ -1,0 +1,84 @@
+# PMG Dependency Maintenance
+
+PMG intentionally keeps a small dependency surface, but it still depends on external .NET packages and GitHub Actions.
+
+The goal of dependency maintenance is not to chase every update immediately. The goal is to make dependency drift and known vulnerabilities visible early enough that maintainers can respond deliberately.
+
+## Sources of dependency visibility
+
+PMG uses three lightweight mechanisms:
+
+1. Dependabot for NuGet package update visibility.
+2. Dependabot for GitHub Actions update visibility.
+3. A dependency vulnerability check workflow using `dotnet list package --vulnerable --include-transitive`.
+
+## Local vulnerability check
+
+Run from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\dependencies\check-dotnet-vulnerabilities.ps1
+```
+
+The script checks:
+
+- `PitmastersGrill\PitmastersGrill.csproj`
+- `PitmastersGrill.Tests\PitmastersGrill.Tests.csproj`
+
+The script fails when `dotnet list package --vulnerable --include-transitive` reports vulnerable packages.
+
+## Dependency update review process
+
+For dependency update PRs:
+
+- [ ] Read what package or action changed.
+- [ ] Check whether the update is routine, security-related, or breaking.
+- [ ] Run restore/build/test locally or rely on CI only when the CI result is clear.
+- [ ] Confirm PMG still launches if the dependency affects app runtime behavior.
+- [ ] Confirm no public-data or EVE boundary changed accidentally.
+- [ ] Prefer one dependency family per PR unless updates are tightly related.
+- [ ] Merge only after validation passes.
+
+## Vulnerability handling
+
+When a vulnerability signal appears:
+
+1. Identify the affected package.
+2. Identify whether PMG uses the affected path.
+3. Prefer updating to a patched version if available.
+4. Run normal validation.
+5. Add release-note or PR context if the vulnerability was user-relevant.
+6. If deferring, document why.
+
+Deferral is acceptable when evidence supports it. Silent deferral is not.
+
+## GitHub settings note
+
+Dependabot configuration can open update PRs, but repository security features such as dependency graph and Dependabot alerts may also need to be enabled in GitHub repository settings.
+
+Suggested GitHub-side checks:
+
+- Dependency graph enabled.
+- Dependabot alerts enabled where available.
+- Dependabot security updates enabled where appropriate.
+- Branch protection requires validation before merge, if the repo is ready for that policy.
+
+## Boundaries
+
+Dependency automation must not change PMG's product boundaries.
+
+It should not:
+
+- add private ESI scopes
+- read the EVE client
+- inspect traffic
+- automate gameplay
+- add telemetry
+- upload user data
+- expand runtime permissions without explicit review
+
+## Release relationship
+
+Before publishing a public release, run the vulnerability check and review any open dependency/security PRs.
+
+This is also listed in `docs/RELEASE-CHECKLIST.md`.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,0 +1,123 @@
+# PMG Release Checklist
+
+This checklist is for maintainers preparing a public PMG release ZIP.
+
+PMG is a Windows desktop app distributed outside a store. Users may see trust prompts, especially while PMG remains unsigned. The goal of this checklist is to make each release repeatable, reviewable, and less dependent on memory.
+
+This checklist does not replace judgment. It gives the release owner a consistent path to follow before publishing.
+
+## Release identity
+
+- [ ] Confirm the intended version number.
+- [ ] Confirm the app version in the project file.
+- [ ] Confirm README current-release references are correct.
+- [ ] Confirm patch notes exist for the release.
+- [ ] Confirm release notes accurately describe PMG's public-data boundaries.
+- [ ] Confirm the release does not imply live grid, cloak, private ESI, client-memory, or network-traffic certainty.
+
+## Local validation
+
+Run from the repository root:
+
+```powershell
+dotnet restore .\PitmastersGrill\PitmastersGrill.slnx
+dotnet build .\PitmastersGrill\PitmastersGrill.slnx --configuration Release --no-restore
+dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj --configuration Release --no-build
+```
+
+- [ ] Restore succeeds.
+- [ ] Release build succeeds.
+- [ ] Tests pass.
+- [ ] No unexpected generated/runtime files are staged for commit.
+
+## Dependency and vulnerability review
+
+Run from the repository root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\dependencies\check-dotnet-vulnerabilities.ps1
+```
+
+- [ ] Dependency vulnerability check succeeds.
+- [ ] Any Dependabot PRs relevant to the release are reviewed.
+- [ ] Any dependency update is validated with normal build/test flow before merge.
+- [ ] If a dependency issue is intentionally deferred, document why in the release notes or PR.
+
+## Manual smoke test
+
+Use a clean local folder when practical.
+
+- [ ] Launch PMG from a clean extracted copy.
+- [ ] Confirm the app opens without crashing.
+- [ ] Copy a small representative EVE local-style list.
+- [ ] Confirm the Grill board populates.
+- [ ] Confirm Analysis still renders.
+- [ ] Confirm Settings opens.
+- [ ] Confirm Help opens.
+- [ ] Confirm diagnostics export still works.
+- [ ] Confirm diagnostics do not expose unwanted local/private data.
+- [ ] Confirm double-click / zKill-open behavior still works where available.
+- [ ] Confirm Ignore List opens and existing ignore behavior is not obviously broken.
+
+## Artifact creation
+
+- [ ] Publish/build from the expected Release output.
+- [ ] Create the release ZIP from the expected files only.
+- [ ] Do not include local databases, diagnostics exports, secrets, user cache, or dev-only files.
+- [ ] Do not include `.git`, `bin`, `obj`, or temporary workspace files unless the release process explicitly expects them.
+- [ ] Name the artifact consistently, including the PMG version.
+
+Example ZIP name:
+
+```text
+Pitmasters-Grill-vX.Y.Z-win-x64.zip
+```
+
+## Artifact verification
+
+Run the verification helper against the release artifact directory:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\release-checks\verify-release-artifacts.ps1 -ReleaseDirectory ".\release"
+```
+
+The helper should:
+
+- validate ZIP readability
+- check for `PitmastersGrill.exe` inside each ZIP
+- generate `SHA256SUMS.txt`
+
+Checklist:
+
+- [ ] ZIP opens successfully.
+- [ ] ZIP contains `PitmastersGrill.exe`.
+- [ ] SHA-256 checksum file generated.
+- [ ] Extract ZIP into a clean folder.
+- [ ] Launch PMG from the clean extracted folder.
+- [ ] Confirm no runtime-only local data was packaged.
+
+## GitHub Release
+
+- [ ] Release title matches the version.
+- [ ] Release notes match patch notes.
+- [ ] Release notes include relevant public-data limitation language when needed.
+- [ ] Release ZIP is attached.
+- [ ] `SHA256SUMS.txt` is attached or the checksum is included in the release body.
+- [ ] README latest-release link points to the new release.
+- [ ] Full release history / patch notes link still works.
+
+## Windows trust note
+
+PMG may still trigger Windows SmartScreen or trust prompts while unsigned.
+
+- [ ] Do not claim code signing unless Authenticode signing is actually implemented.
+- [ ] If unsigned, keep the release notes and Windows publishing trust documentation honest.
+- [ ] Leave room for future Authenticode signing/timestamping without blocking current releases.
+
+## Post-release
+
+- [ ] Download the release asset from GitHub.
+- [ ] Verify checksum against the published checksum.
+- [ ] Extract and launch from a clean folder.
+- [ ] Confirm the release page displays the intended artifact and notes.
+- [ ] Close release-process issues only after the published artifact is verified.

--- a/tools/dependencies/check-dotnet-vulnerabilities.ps1
+++ b/tools/dependencies/check-dotnet-vulnerabilities.ps1
@@ -1,0 +1,48 @@
+[CmdletBinding()]
+param(
+    [string[]]$Projects = @(
+        "PitmastersGrill\PitmastersGrill.csproj",
+        "PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"
+    )
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== PMG dependency vulnerability check ==="
+
+$foundVulnerability = $false
+
+foreach ($project in $Projects) {
+    if (-not (Test-Path $project)) {
+        throw "Project file not found: $project"
+    }
+
+    Write-Host ""
+    Write-Host "Checking $project"
+    Write-Host "----------------------------------------"
+
+    $output = & dotnet list $project package --vulnerable --include-transitive 2>&1
+    $exitCode = $LASTEXITCODE
+
+    $output | ForEach-Object { Write-Host $_ }
+
+    if ($exitCode -ne 0) {
+        throw "dotnet list package failed for $project with exit code $exitCode"
+    }
+
+    $joinedOutput = ($output | Out-String)
+
+    if ($joinedOutput -match "has the following vulnerable packages") {
+        $foundVulnerability = $true
+    }
+}
+
+Write-Host ""
+
+if ($foundVulnerability) {
+    Write-Error "One or more vulnerable package reports were found."
+    exit 1
+}
+
+Write-Host "No vulnerable package reports found."
+exit 0

--- a/tools/release-checks/verify-release-artifacts.ps1
+++ b/tools/release-checks/verify-release-artifacts.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseDirectory,
+
+    [string]$ExpectedExeName = "PitmastersGrill.exe",
+
+    [string]$ChecksumFileName = "SHA256SUMS.txt"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== PMG release artifact verification ==="
+
+if (-not (Test-Path $ReleaseDirectory)) {
+    throw "Release directory not found: $ReleaseDirectory"
+}
+
+$releasePath = Resolve-Path $ReleaseDirectory
+$zipFiles = Get-ChildItem -Path $releasePath -Filter "*.zip" -File | Sort-Object Name
+
+if ($zipFiles.Count -eq 0) {
+    throw "No ZIP artifacts found in: $releasePath"
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$checksumLines = New-Object System.Collections.Generic.List[string]
+$hadFailure = $false
+
+foreach ($zip in $zipFiles) {
+    Write-Host ""
+    Write-Host "Verifying $($zip.Name)"
+    Write-Host "----------------------------------------"
+
+    try {
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($zip.FullName)
+
+        try {
+            $entries = @($archive.Entries)
+            $exeEntry = $entries | Where-Object {
+                [System.IO.Path]::GetFileName($_.FullName) -ieq $ExpectedExeName
+            } | Select-Object -First 1
+
+            if (-not $exeEntry) {
+                Write-Error "Expected executable was not found in ZIP: $ExpectedExeName"
+                $hadFailure = $true
+            }
+            else {
+                Write-Host "Found executable: $($exeEntry.FullName)"
+            }
+
+            Write-Host "ZIP entries: $($entries.Count)"
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+    catch {
+        Write-Error "ZIP validation failed for $($zip.Name): $_"
+        $hadFailure = $true
+    }
+
+    $hash = Get-FileHash -Algorithm SHA256 -Path $zip.FullName
+    $line = "$($hash.Hash.ToLowerInvariant())  $($zip.Name)"
+    $checksumLines.Add($line)
+    Write-Host "SHA256: $($hash.Hash)"
+}
+
+$checksumPath = Join-Path $releasePath $ChecksumFileName
+$checksumLines | Set-Content -Path $checksumPath -Encoding UTF8
+
+Write-Host ""
+Write-Host "Wrote checksum file: $checksumPath"
+
+if ($hadFailure) {
+    Write-Error "One or more release artifact checks failed."
+    exit 1
+}
+
+Write-Host "Release artifact verification completed successfully."
+exit 0


### PR DESCRIPTION
## Summary

Adds the PMG release trust and maintenance foundation for v1.3.0 planning.

Includes:
- maintainer release checklist
- release artifact verification/checksum helper
- dependency maintenance guide
- Dependabot configuration for NuGet and GitHub Actions
- dependency vulnerability check workflow
- local vulnerability check helper script

## Validation

Local validation to run before merge:

- `dotnet restore .\PitmastersGrill\PitmastersGrill.slnx`
- `dotnet build .\PitmastersGrill\PitmastersGrill.slnx --configuration Release --no-restore`
- `dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj --configuration Release --no-build`
- `powershell -ExecutionPolicy Bypass -File .\tools\dependencies\check-dotnet-vulnerabilities.ps1`

## Issues

Closes #30
Closes #31
