### PR TITLE
Add signal reference and board layout persistence

### DIFF
--- a/FIRST-TIME-USE.md
+++ b/FIRST-TIME-USE.md
@@ -277,3 +277,9 @@ Continue with:
 - [`HOW-IT-WORKS.md`](./HOW-IT-WORKS.md)
 - [`EVE-TOS-COMPLIANCE.md`](./EVE-TOS-COMPLIANCE.md)
 - [`HOW-TO-NAVIGATE-THIS-REPO.md`](./HOW-TO-NAVIGATE-THIS-REPO.md)
+
+## Reading PMG Signals
+
+PMG signals are public historical evidence summaries. They are useful prompts for judgment, but they do not prove what a pilot is currently flying, fitting, doing, or intending.
+
+Use the in-app Help > Signal Reference section or `SIGNAL-REFERENCE.md` when a signal label is unclear.

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -386,3 +386,15 @@ PMG supports judgment. It does not replace it.
 - [`FIRST-TIME-USE.md`](./FIRST-TIME-USE.md)
 - [`EVE-TOS-COMPLIANCE.md`](./EVE-TOS-COMPLIANCE.md)
 - [`DEVELOPER-NOTES.md`](./DEVELOPER-NOTES.md)
+
+## Signal Interpretation Reference
+
+PMG signal labels are evidence summaries, not live-certainty claims.
+
+- Confirmed covert means PMG found recent public killmail-derived evidence involving a Covert Cynosural Field Generator I.
+- Confirmed normal means PMG found recent public killmail-derived evidence involving a regular Cynosural Field Generator I.
+- Possible means PMG has meaningful evidence, but not enough for recent confirmed module evidence.
+- Inferred means weak public evidence exists, often from cyno-capable hull observations or related context.
+- Bait means PMG found public loss evidence where an industrial cyno and tackle module appeared together.
+
+See `SIGNAL-REFERENCE.md` for the full explanation.

--- a/PitmastersGrill.Tests/Services/SignalReferenceCatalogTests.cs
+++ b/PitmastersGrill.Tests/Services/SignalReferenceCatalogTests.cs
@@ -1,0 +1,36 @@
+using PitmastersGrill.Services;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class SignalReferenceCatalogTests
+    {
+        [Fact]
+        public void Entries_IncludeExpectedSignalLabels()
+        {
+            var labels = SignalReferenceCatalog.Entries.Select(entry => entry.Label).ToList();
+
+            Assert.Contains("Confirmed covert", labels);
+            Assert.Contains("Confirmed normal", labels);
+            Assert.Contains("Possible", labels);
+            Assert.Contains("Inferred", labels);
+            Assert.Contains("Bait", labels);
+        }
+
+        [Fact]
+        public void RequiredCaveat_DoesNotClaimLiveCertainty()
+        {
+            Assert.Contains("public historical evidence summaries", SignalReferenceCatalog.RequiredCaveat);
+            Assert.Contains("does not make live-certainty claims", SignalReferenceCatalog.RequiredCaveat);
+        }
+
+        [Fact]
+        public void FindByLabel_IsCaseInsensitive()
+        {
+            var entry = SignalReferenceCatalog.FindByLabel("confirmed covert");
+
+            Assert.NotNull(entry);
+            Assert.Contains("Covert Cynosural Field Generator I", entry!.PlainLanguageMeaning);
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/WindowLayoutControllerModeTests.cs
+++ b/PitmastersGrill.Tests/Services/WindowLayoutControllerModeTests.cs
@@ -1,0 +1,89 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System.Windows;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class WindowLayoutControllerModeTests
+    {
+        private static readonly IReadOnlyList<Rect> WorkAreas = [new Rect(0, 0, 1920, 1080)];
+
+        [Fact]
+        public void ApplySnapshot_StoresNormalAndBoardLayoutsIndependently()
+        {
+            var settings = new AppSettings();
+            var controller = new WindowLayoutController();
+
+            controller.ApplySnapshot(
+                settings,
+                new WindowLayoutSnapshot { Left = 10, Top = 20, Width = 800, Height = 600, IsMaximized = false },
+                WindowLayoutMode.Normal);
+
+            controller.ApplySnapshot(
+                settings,
+                new WindowLayoutSnapshot { Left = 100, Top = 120, Width = 500, Height = 420, IsMaximized = true },
+                WindowLayoutMode.Board);
+
+            Assert.True(controller.TryGetSavedWindowBounds(settings, WindowLayoutMode.Normal, out var normalBounds));
+            Assert.True(controller.TryGetSavedWindowBounds(settings, WindowLayoutMode.Board, out var boardBounds));
+
+            Assert.Equal(new Rect(10, 20, 800, 600), normalBounds);
+            Assert.Equal(new Rect(100, 120, 500, 420), boardBounds);
+            Assert.False(controller.IsSavedLayoutMaximized(settings, WindowLayoutMode.Normal));
+            Assert.True(controller.IsSavedLayoutMaximized(settings, WindowLayoutMode.Board));
+        }
+
+        [Fact]
+        public void TryGetSavedWindowBounds_NormalFallsBackToLegacyLayout()
+        {
+            var settings = new AppSettings
+            {
+                SavedWindowLeft = 30,
+                SavedWindowTop = 40,
+                SavedWindowWidth = 900,
+                SavedWindowHeight = 700
+            };
+
+            var controller = new WindowLayoutController();
+
+            var found = controller.TryGetSavedWindowBounds(settings, WindowLayoutMode.Normal, out var bounds);
+
+            Assert.True(found);
+            Assert.Equal(new Rect(30, 40, 900, 700), bounds);
+        }
+
+        [Fact]
+        public void BuildRestoreResult_UsesRequestedMode()
+        {
+            var settings = new AppSettings
+            {
+                SavedNormalWindowLeft = 10,
+                SavedNormalWindowTop = 20,
+                SavedNormalWindowWidth = 800,
+                SavedNormalWindowHeight = 600,
+                SavedBoardWindowLeft = 100,
+                SavedBoardWindowTop = 120,
+                SavedBoardWindowWidth = 500,
+                SavedBoardWindowHeight = 420
+            };
+
+            var controller = new WindowLayoutController();
+
+            var boardResult = controller.BuildRestoreResult(
+                settings,
+                WindowLayoutMode.Board,
+                420,
+                300,
+                420,
+                300,
+                80,
+                760,
+                571,
+                WorkAreas);
+
+            Assert.Equal(new Rect(100, 120, 500, 420), boardResult.TargetBounds);
+            Assert.Equal("Applied", boardResult.RestoreDecision);
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml
+++ b/PitmastersGrill/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="PitmastersGrill.MainWindow"
+<Window x:Class="PitmastersGrill.MainWindow"
         x:Name="RootWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -2395,7 +2395,61 @@
                 </TabItem>
 
                 <TabItem Header="Help">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <TabItem.Resources>
+                    <Style x:Key="HelpSubTabControlStyle" TargetType="{x:Type TabControl}">
+                        <Setter Property="Background" Value="#101418" />
+                        <Setter Property="BorderBrush" Value="#3A4652" />
+                        <Setter Property="Foreground" Value="#F2EFE6" />
+                    </Style>
+
+                    <Style x:Key="HelpSubTabItemStyle" TargetType="{x:Type TabItem}">
+                        <Setter Property="Foreground" Value="#F2EFE6" />
+                        <Setter Property="Background" Value="#1E252C" />
+                        <Setter Property="BorderBrush" Value="#3A4652" />
+                        <Setter Property="Padding" Value="10,4" />
+                        <Setter Property="Margin" Value="0,0,2,0" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type TabItem}">
+                                    <Border
+                                        x:Name="TabBorder"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="1"
+                                        Padding="{TemplateBinding Padding}"
+                                        Margin="{TemplateBinding Margin}">
+                                        <ContentPresenter
+                                            x:Name="ContentSite"
+                                            ContentSource="Header"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            RecognizesAccessKey="True" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="TabBorder" Property="Background" Value="#2A333C" />
+                                            <Setter TargetName="TabBorder" Property="BorderBrush" Value="#52C7EA" />
+                                            <Setter Property="Foreground" Value="#FFFFFF" />
+                                            <Setter Property="Panel.ZIndex" Value="10" />
+                                        </Trigger>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="TabBorder" Property="Background" Value="#24303A" />
+                                        </Trigger>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter Property="Foreground" Value="#7E8A95" />
+                                            <Setter TargetName="TabBorder" Property="Opacity" Value="0.7" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </TabItem.Resources>
+                    <TabControl Style="{StaticResource HelpSubTabControlStyle}" Background="#101418" BorderBrush="#3A4652" Foreground="#F2EFE6">
+                        <TabItem Header="General / Getting Started" Style="{StaticResource HelpSubTabItemStyle}" Background="#1E252C" Foreground="#F2EFE6">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto" Background="#101418">
+                                <StackPanel Margin="8" Background="#101418">
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto" Background="#101418">
                         <StackPanel Margin="16">
                             <TextBlock Text="PMG Help"
                                        FontSize="22"
@@ -2551,6 +2605,34 @@
                             </Border>
                         </StackPanel>
                     </ScrollViewer>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </TabItem>
+
+                        <TabItem Header="Signal Reference" Style="{StaticResource HelpSubTabItemStyle}" Background="#1E252C" Foreground="#F2EFE6">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto" Background="#101418">
+                                <StackPanel Margin="8" Background="#101418">
+                                    <TextBlock Text="PMG Signal Reference" FontSize="18" FontWeight="SemiBold" Foreground="#F2EFE6" Margin="0,0,0,8" />
+                                    <TextBlock Text="PMG signals are public historical evidence summaries. They do not prove that a pilot is currently in that ship, currently fit that way, uncloaked, on-grid, or actively baiting. PMG summarizes public evidence so users can make better decisions; it does not make live-certainty claims." TextWrapping="Wrap" Foreground="#F2EFE6" Margin="0,0,0,12" />
+
+                                    <TextBlock Text="Confirmed covert" FontWeight="SemiBold" Foreground="#F2EFE6" Margin="0,8,0,2" />
+                                    <TextBlock Text="PMG found recent public killmail-derived module evidence showing a Covert Cynosural Field Generator I." TextWrapping="Wrap" Foreground="#F2EFE6" />
+
+                                    <TextBlock Text="Confirmed normal" FontWeight="SemiBold" Foreground="#F2EFE6" Margin="0,8,0,2" />
+                                    <TextBlock Text="PMG found recent public killmail-derived module evidence showing a regular Cynosural Field Generator I. In code this is the normal cyno type; in one UI/context it may also display as hard." TextWrapping="Wrap" Foreground="#F2EFE6" />
+
+                                    <TextBlock Text="Possible" FontWeight="SemiBold" Foreground="#F2EFE6" Margin="0,8,0,2" />
+                                    <TextBlock Text="PMG has meaningful evidence, but not enough for recent confirmed module evidence. This can come from stale or unknown-age module evidence, or from combined weaker signals." TextWrapping="Wrap" Foreground="#F2EFE6" />
+
+                                    <TextBlock Text="Inferred" FontWeight="SemiBold" Foreground="#F2EFE6" Margin="0,8,0,2" />
+                                    <TextBlock Text="Weak evidence exists, usually from cyno-capable hull observations, public activity, or related context, but no confirmed cyno module was found." TextWrapping="Wrap" Foreground="#F2EFE6" />
+
+                                    <TextBlock Text="Bait" FontWeight="SemiBold" Foreground="#F2EFE6" Margin="0,8,0,2" />
+                                    <TextBlock Text="PMG found public loss evidence where an industrial cyno and a tackle module, such as a warp scrambler or warp disruptor, appeared together. This suggests possible industrial cyno bait, but it is still evidence-based and not proof of intent." TextWrapping="Wrap" Foreground="#F2EFE6" />
+                                </StackPanel>
+                            </ScrollViewer>
+                        </TabItem>
+                    </TabControl>
                 </TabItem>
             </TabControl>
 

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using PitmastersGrill.Diagnostics;
+using PitmastersGrill.Diagnostics;
 using PitmastersGrill.Models;
 using PitmastersGrill.Persistence;
 using PitmastersGrill.Providers;
@@ -101,7 +101,7 @@ namespace PitmastersGrill
         private readonly CacheMaintenanceService _cacheMaintenanceService = new();
         private readonly KillmailDerivedIntelRebuildService _killmailDerivedIntelRebuildService = new();
         private PilotDetailWindow? _activePilotDetailWindow;
-        private bool _isApplyingSettings;
+        private bool _isApplyingSettings; private bool _isRestoringWindowLayout;
         private bool _isShuttingDown;
         private bool _compactDragPending;
         private Point _compactDragStartPoint;
@@ -367,59 +367,7 @@ namespace PitmastersGrill
             ApplyCompactModeUi();
         }
 
-        private void ApplyCompactModeUi()
-        {
-            if (CompactModeToggleButton == null || MainContentGrid == null || TopCommandGrid == null || MainTabControl == null || BoardStatusFooter == null)
-            {
-                return;
-            }
-
-            var compact = CompactModeToggleButton.IsChecked == true;
-            var previousCompactMode = _lastAppliedCompactMode;
-            _lastAppliedCompactMode = compact;
-
-            if (compact)
-            {
-                MainTabControl.SelectedIndex = 1;
-                CloseActiveDetailWindow();
-            }
-
-            TopCommandGrid.Visibility = compact ? Visibility.Collapsed : Visibility.Visible;
-            TopCommandGrid.Margin = new Thickness(0, 0, 0, 6);
-            BoardStatusFooter.Padding = new Thickness(8, 5, 8, 5);
-            MainContentGrid.Margin = compact ? new Thickness(1) : new Thickness(12);
-            MainTabControl.BorderThickness = compact ? new Thickness(0) : new Thickness(1);
-            MainTabControl.Margin = compact ? new Thickness(0) : new Thickness(0);
-
-            if (!_isApplyingSettings && _appSettings.CompactModeEnabled != compact)
-            {
-                _appSettings.CompactModeEnabled = compact;
-                _mainWindowAppearanceController.SaveSettings(_appSettings);
-            }
-
-            if (!_isApplyingSettings &&
-                (!previousCompactMode.HasValue || previousCompactMode.Value != compact))
-            {
-                AppLogger.UiInfo($"Display mode changed. boardMode={compact}");
-            }
-
-            if (compact && !_isApplyingSettings &&
-                (!previousCompactMode.HasValue || previousCompactMode.Value != compact))
-            {
-                ShowBoardModeHint();
-            }
-            else if (!compact)
-            {
-                HideBoardModeHint();
-            }
-
-            UpdateWindowMinimumSize();
-            UpdateBoardFooterVisibility();
-            UpdateBoardSummaryBanner();
-            UpdateAnalysisTab();
-        }
-
-        private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void ApplyCompactModeUi() { if (CompactModeToggleButton == null || MainContentGrid == null || TopCommandGrid == null || MainTabControl == null || BoardStatusFooter == null) { return; } var compact = CompactModeToggleButton.IsChecked == true; var previousCompactMode = _lastAppliedCompactMode; var displayModeChanged = !_isApplyingSettings && !_isRestoringWindowLayout && previousCompactMode.HasValue && previousCompactMode.Value != compact; if (displayModeChanged) { SaveWindowLayoutToSettings($"Before display mode change to {(compact ? "Board" : "Normal")}", previousCompactMode.Value ? WindowLayoutMode.Board : WindowLayoutMode.Normal); } _lastAppliedCompactMode = compact; if (compact) { MainTabControl.SelectedIndex = 1; CloseActiveDetailWindow(); } TopCommandGrid.Visibility = compact ? Visibility.Collapsed : Visibility.Visible; TopCommandGrid.Margin = new Thickness(0, 0, 0, 6); BoardStatusFooter.Padding = new Thickness(8, 5, 8, 5); MainContentGrid.Margin = compact ? new Thickness(1) : new Thickness(12); MainTabControl.BorderThickness = compact ? new Thickness(0) : new Thickness(1); MainTabControl.Margin = compact ? new Thickness(0) : new Thickness(0); if (!_isApplyingSettings && _appSettings.CompactModeEnabled != compact) { _appSettings.CompactModeEnabled = compact; _mainWindowAppearanceController.SaveSettings(_appSettings); } if (!_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { AppLogger.UiInfo($"Display mode changed.\nboardMode={compact}"); } if (compact && !_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { ShowBoardModeHint(); } else if (!compact) { HideBoardModeHint(); } UpdateWindowMinimumSize(); if (displayModeChanged) { RestoreWindowLayoutFromSettings(compact ? WindowLayoutMode.Board : WindowLayoutMode.Normal); } UpdateBoardFooterVisibility(); UpdateBoardSummaryBanner(); UpdateAnalysisTab(); } private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!ReferenceEquals(sender, MainTabControl))
             {
@@ -4506,95 +4454,7 @@ namespace PitmastersGrill
             }
         }
 
-        private void RestoreWindowLayoutFromSettings()
-        {
-            var workAreas = GetMonitorWorkAreasDip();
-            var virtualDesktopSummary = _windowLayoutController.BuildVirtualDesktopSummary(workAreas);
-            var restoreResult = _windowLayoutController.BuildRestoreResult(
-                _appSettings,
-                MinWidth,
-                MinHeight,
-                MinimumSavedWindowWidth,
-                MinimumSavedWindowHeight,
-                MinimumVisibleWindowEdge,
-                DefaultWindowWidth,
-                DefaultWindowHeight,
-                workAreas);
-
-            AppLogger.UiInfo(
-                $"Window layout restore decision={restoreResult.RestoreDecision} savedBounds={_windowLayoutController.DescribeRect(restoreResult.SavedBounds)} fallbackReason='{restoreResult.RestoreReason}' wasMaximized={_appSettings.SavedWindowIsMaximized} virtualWorkAreas={virtualDesktopSummary}");
-
-            WindowState = WindowState.Normal;
-            Left = restoreResult.TargetBounds.Left;
-            Top = restoreResult.TargetBounds.Top;
-            Width = restoreResult.TargetBounds.Width;
-            Height = restoreResult.TargetBounds.Height;
-            _lastKnownNormalBounds = restoreResult.TargetBounds;
-
-            if (restoreResult.ShouldRestoreMaximized)
-            {
-                WindowState = WindowState.Maximized;
-            }
-
-            _lastNonMinimizedWindowState = restoreResult.LastNonMinimizedWindowState;
-
-            AppLogger.UiInfo(
-                $"Window layout restore applied finalBounds={_windowLayoutController.DescribeRect(restoreResult.TargetBounds)} finalWindowState={WindowState}");
-        }
-
-        private void SaveWindowLayoutToSettings(string reason)
-        {
-            var effectiveState = WindowState == WindowState.Minimized
-                ? _lastNonMinimizedWindowState
-                : WindowState;
-
-            if (effectiveState == WindowState.Maximized && _windowLayoutController.IsUsableWindowBounds(RestoreBounds))
-            {
-                _lastKnownNormalBounds = RestoreBounds;
-            }
-            else if (WindowState == WindowState.Normal)
-            {
-                TrackCurrentNormalWindowBounds("Save");
-            }
-
-            var bounds = _windowLayoutController.IsUsableWindowBounds(_lastKnownNormalBounds)
-                ? _lastKnownNormalBounds
-                : effectiveState == WindowState.Maximized
-                    ? RestoreBounds
-                    : new Rect(Left, Top, Width, Height);
-
-            var workAreas = GetMonitorWorkAreasDip();
-            if (!_windowLayoutController.TryBuildLayoutSnapshot(
-                    bounds,
-                    effectiveState,
-                    MinWidth,
-                    MinHeight,
-                    MinimumSavedWindowWidth,
-                    MinimumSavedWindowHeight,
-                    MinimumVisibleWindowEdge,
-                    workAreas,
-                    out var snapshot,
-                    out var failureReason))
-            {
-                AppLogger.UiWarn(
-                    $"Window layout save skipped. reason='{reason}' bounds={_windowLayoutController.DescribeRect(bounds)} failureReason='{failureReason}' virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}");
-                return;
-            }
-
-            _windowLayoutController.ApplySnapshot(_appSettings, snapshot);
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-
-            AppLogger.UiInfo(
-                $"Window layout saved. reason='{reason}' bounds={_windowLayoutController.DescribeRect(bounds)} maximized={_appSettings.SavedWindowIsMaximized} virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}");
-        }
-
-        private void ClearSavedWindowLayoutSettings()
-        {
-            _windowLayoutController.ClearSavedLayout(_appSettings);
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-        }
-
-        private Rect GetDefaultWindowBoundsForCurrentDisplay()
+        private WindowLayoutMode GetCurrentWindowLayoutMode() { return CompactModeToggleButton?.IsChecked == true ? WindowLayoutMode.Board : WindowLayoutMode.Normal; } private void RestoreWindowLayoutFromSettings() { RestoreWindowLayoutFromSettings(GetCurrentWindowLayoutMode()); } private void RestoreWindowLayoutFromSettings(WindowLayoutMode mode) { var workAreas = GetMonitorWorkAreasDip(); var virtualDesktopSummary = _windowLayoutController.BuildVirtualDesktopSummary(workAreas); var restoreResult = _windowLayoutController.BuildRestoreResult( _appSettings, mode, MinWidth, MinHeight, MinimumSavedWindowWidth, MinimumSavedWindowHeight, MinimumVisibleWindowEdge, DefaultWindowWidth, DefaultWindowHeight, workAreas); AppLogger.UiInfo( $"Window layout restore decision={restoreResult.RestoreDecision} mode={mode} savedBounds={_windowLayoutController.DescribeRect(restoreResult.SavedBounds)} fallbackReason='{restoreResult.RestoreReason}' wasMaximized={restoreResult.ShouldRestoreMaximized} virtualWorkAreas={virtualDesktopSummary}"); _isRestoringWindowLayout = true; try { WindowState = WindowState.Normal; Left = restoreResult.TargetBounds.Left; Top = restoreResult.TargetBounds.Top; Width = restoreResult.TargetBounds.Width; Height = restoreResult.TargetBounds.Height; _lastKnownNormalBounds = restoreResult.TargetBounds; if (restoreResult.ShouldRestoreMaximized) { WindowState = WindowState.Maximized; } _lastNonMinimizedWindowState = restoreResult.LastNonMinimizedWindowState; } finally { _isRestoringWindowLayout = false; } AppLogger.UiInfo( $"Window layout restore applied mode={mode} finalBounds={_windowLayoutController.DescribeRect(restoreResult.TargetBounds)} finalWindowState={WindowState}"); } private void SaveWindowLayoutToSettings(string reason) { SaveWindowLayoutToSettings(reason, GetCurrentWindowLayoutMode()); } private void SaveWindowLayoutToSettings(string reason, WindowLayoutMode mode) { var effectiveState = WindowState == WindowState.Minimized ? _lastNonMinimizedWindowState : WindowState; if (effectiveState == WindowState.Maximized && _windowLayoutController.IsUsableWindowBounds(RestoreBounds)) { _lastKnownNormalBounds = RestoreBounds; } else if (WindowState == WindowState.Normal) { TrackCurrentNormalWindowBounds("Save"); } var bounds = _windowLayoutController.IsUsableWindowBounds(_lastKnownNormalBounds) ? _lastKnownNormalBounds : effectiveState == WindowState.Maximized ? RestoreBounds : new Rect(Left, Top, Width, Height); var workAreas = GetMonitorWorkAreasDip(); if (!_windowLayoutController.TryBuildLayoutSnapshot( bounds, effectiveState, MinWidth, MinHeight, MinimumSavedWindowWidth, MinimumSavedWindowHeight, MinimumVisibleWindowEdge, workAreas, out var snapshot, out var failureReason)) { AppLogger.UiWarn( $"Window layout save skipped.\nreason='{reason}' mode={mode} bounds={_windowLayoutController.DescribeRect(bounds)} failureReason='{failureReason}' virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}"); return; } _windowLayoutController.ApplySnapshot(_appSettings, snapshot, mode); _mainWindowAppearanceController.SaveSettings(_appSettings); AppLogger.UiInfo( $"Window layout saved.\nreason='{reason}' mode={mode} bounds={_windowLayoutController.DescribeRect(bounds)} maximized={snapshot.IsMaximized} virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}"); } private void ClearSavedWindowLayoutSettings() { _windowLayoutController.ClearAllSavedLayouts(_appSettings); _mainWindowAppearanceController.SaveSettings(_appSettings); } private Rect GetDefaultWindowBoundsForCurrentDisplay()
         {
             return _windowLayoutController.GetDefaultWindowBounds(
                 GetMonitorWorkAreasDip(),

--- a/PitmastersGrill/Models/AppSettings.cs
+++ b/PitmastersGrill/Models/AppSettings.cs
@@ -26,6 +26,7 @@ namespace PitmastersGrill.Models
 
         public string BoardFontFamily { get; set; } = string.Empty;
 
+        // Legacy normal-window layout fields retained for backward compatibility with existing settings.json files.
         public double? SavedWindowLeft { get; set; }
 
         public double? SavedWindowTop { get; set; }
@@ -35,6 +36,28 @@ namespace PitmastersGrill.Models
         public double? SavedWindowHeight { get; set; }
 
         public bool SavedWindowIsMaximized { get; set; } = false;
+
+        // Normal mode layout.
+        public double? SavedNormalWindowLeft { get; set; }
+
+        public double? SavedNormalWindowTop { get; set; }
+
+        public double? SavedNormalWindowWidth { get; set; }
+
+        public double? SavedNormalWindowHeight { get; set; }
+
+        public bool SavedNormalWindowIsMaximized { get; set; } = false;
+
+        // Board mode layout.
+        public double? SavedBoardWindowLeft { get; set; }
+
+        public double? SavedBoardWindowTop { get; set; }
+
+        public double? SavedBoardWindowWidth { get; set; }
+
+        public double? SavedBoardWindowHeight { get; set; }
+
+        public bool SavedBoardWindowIsMaximized { get; set; } = false;
 
         public bool ShowCorpAllianceCounts { get; set; } = false;
 

--- a/PitmastersGrill/Models/WindowLayoutMode.cs
+++ b/PitmastersGrill/Models/WindowLayoutMode.cs
@@ -1,0 +1,8 @@
+namespace PitmastersGrill.Models
+{
+    public enum WindowLayoutMode
+    {
+        Normal,
+        Board
+    }
+}

--- a/PitmastersGrill/Services/SignalReferenceCatalog.cs
+++ b/PitmastersGrill/Services/SignalReferenceCatalog.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PitmastersGrill.Services
+{
+    public sealed record SignalReferenceEntry(
+        string Label,
+        string PlainLanguageMeaning,
+        string ImportantCaveat);
+
+    public static class SignalReferenceCatalog
+    {
+        private static readonly IReadOnlyList<SignalReferenceEntry> EntriesValue =
+        [
+            new(
+                "Confirmed covert",
+                "PMG found recent public killmail-derived module evidence showing a Covert Cynosural Field Generator I.",
+                "This does not prove the pilot is currently in a covert cyno ship or currently fit that way."),
+
+            new(
+                "Confirmed normal",
+                "PMG found recent public killmail-derived module evidence showing a regular Cynosural Field Generator I. In code this is the normal cyno type; in one UI context it may also display as hard.",
+                "This does not prove the pilot is currently carrying or using a normal cyno."),
+
+            new(
+                "Possible",
+                "PMG has meaningful evidence, but not enough for recent confirmed module evidence. This can come from stale or unknown-age module evidence or combined weaker signals.",
+                "Treat this as a review prompt, not a live-certainty claim."),
+
+            new(
+                "Inferred",
+                "Weak evidence exists, usually from cyno-capable hull observations, public activity, or related context, but no confirmed cyno module was found.",
+                "Inferred signals are intentionally weaker than confirmed module evidence."),
+
+            new(
+                "Bait",
+                "PMG found public loss evidence where an industrial cyno and a tackle module, such as a warp scrambler or warp disruptor, appeared together.",
+                "This suggests possible industrial cyno bait, but it is still evidence-based and not proof of intent.")
+        ];
+
+        public static IReadOnlyList<SignalReferenceEntry> Entries => EntriesValue;
+
+        public static string RequiredCaveat =>
+            "PMG signals are public historical evidence summaries. They do not prove that a pilot is currently in that ship, currently fit that way, uncloaked, on-grid, or actively baiting. PMG summarizes public evidence so users can make better decisions; it does not make live-certainty claims.";
+
+        public static string BuildPlainTextReference()
+        {
+            var lines = new List<string>
+            {
+                "PMG Signal Reference",
+                string.Empty,
+                RequiredCaveat,
+                string.Empty
+            };
+
+            foreach (var entry in Entries)
+            {
+                lines.Add(entry.Label);
+                lines.Add(entry.PlainLanguageMeaning);
+                lines.Add(entry.ImportantCaveat);
+                lines.Add(string.Empty);
+            }
+
+            return string.Join(System.Environment.NewLine, lines).TrimEnd();
+        }
+
+        public static SignalReferenceEntry? FindByLabel(string label)
+        {
+            return Entries.FirstOrDefault(entry =>
+                string.Equals(entry.Label, label, System.StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/PitmastersGrill/Services/WindowLayoutController.cs
+++ b/PitmastersGrill/Services/WindowLayoutController.cs
@@ -9,11 +9,17 @@ namespace PitmastersGrill.Services
     public sealed class WindowLayoutRestoreResult
     {
         public required Rect TargetBounds { get; init; }
+
         public required string RestoreDecision { get; init; }
+
         public required string RestoreReason { get; init; }
+
         public required bool HasSavedBounds { get; init; }
+
         public required Rect SavedBounds { get; init; }
+
         public required bool ShouldRestoreMaximized { get; init; }
+
         public required WindowState LastNonMinimizedWindowState { get; init; }
     }
 
@@ -21,6 +27,31 @@ namespace PitmastersGrill.Services
     {
         public WindowLayoutRestoreResult BuildRestoreResult(
             AppSettings settings,
+            double minWidth,
+            double minHeight,
+            double minimumSavedWindowWidth,
+            double minimumSavedWindowHeight,
+            double minimumVisibleWindowEdge,
+            double defaultWindowWidth,
+            double defaultWindowHeight,
+            IReadOnlyList<Rect> workAreas)
+        {
+            return BuildRestoreResult(
+                settings,
+                WindowLayoutMode.Normal,
+                minWidth,
+                minHeight,
+                minimumSavedWindowWidth,
+                minimumSavedWindowHeight,
+                minimumVisibleWindowEdge,
+                defaultWindowWidth,
+                defaultWindowHeight,
+                workAreas);
+        }
+
+        public WindowLayoutRestoreResult BuildRestoreResult(
+            AppSettings settings,
+            WindowLayoutMode mode,
             double minWidth,
             double minHeight,
             double minimumSavedWindowWidth,
@@ -42,7 +73,7 @@ namespace PitmastersGrill.Services
                 defaultWindowWidth,
                 defaultWindowHeight);
 
-            var hasSavedBounds = TryGetSavedWindowBounds(settings, out var savedBounds);
+            var hasSavedBounds = TryGetSavedWindowBounds(settings, mode, out var savedBounds);
             Rect targetBounds;
             string restoreDecision;
             string restoreReason;
@@ -51,17 +82,17 @@ namespace PitmastersGrill.Services
             {
                 targetBounds = fallbackBounds;
                 restoreDecision = "Fallback";
-                restoreReason = "No saved bounds were available.";
+                restoreReason = $"No saved {mode} bounds were available.";
             }
             else if (!TryValidateWindowBounds(
-                         savedBounds,
-                         minWidth,
-                         minHeight,
-                         minimumSavedWindowWidth,
-                         minimumSavedWindowHeight,
-                         minimumVisibleWindowEdge,
-                         workAreas,
-                         out var failureReason))
+                savedBounds,
+                minWidth,
+                minHeight,
+                minimumSavedWindowWidth,
+                minimumSavedWindowHeight,
+                minimumVisibleWindowEdge,
+                workAreas,
+                out var failureReason))
             {
                 targetBounds = fallbackBounds;
                 restoreDecision = "Fallback";
@@ -71,8 +102,10 @@ namespace PitmastersGrill.Services
             {
                 targetBounds = savedBounds;
                 restoreDecision = "Applied";
-                restoreReason = "Saved bounds are visible on the current monitor layout.";
+                restoreReason = $"Saved {mode} bounds are visible on the current monitor layout.";
             }
+
+            var shouldRestoreMaximized = IsSavedLayoutMaximized(settings, mode);
 
             return new WindowLayoutRestoreResult
             {
@@ -81,10 +114,8 @@ namespace PitmastersGrill.Services
                 RestoreReason = restoreReason,
                 HasSavedBounds = hasSavedBounds,
                 SavedBounds = hasSavedBounds ? savedBounds : Rect.Empty,
-                ShouldRestoreMaximized = settings.SavedWindowIsMaximized,
-                LastNonMinimizedWindowState = settings.SavedWindowIsMaximized
-                    ? WindowState.Maximized
-                    : WindowState.Normal
+                ShouldRestoreMaximized = shouldRestoreMaximized,
+                LastNonMinimizedWindowState = shouldRestoreMaximized ? WindowState.Maximized : WindowState.Normal
             };
         }
 
@@ -103,14 +134,14 @@ namespace PitmastersGrill.Services
             snapshot = new WindowLayoutSnapshot();
 
             if (!TryValidateWindowBounds(
-                    bounds,
-                    minWidth,
-                    minHeight,
-                    minimumSavedWindowWidth,
-                    minimumSavedWindowHeight,
-                    minimumVisibleWindowEdge,
-                    workAreas,
-                    out failureReason))
+                bounds,
+                minWidth,
+                minHeight,
+                minimumSavedWindowWidth,
+                minimumSavedWindowHeight,
+                minimumVisibleWindowEdge,
+                workAreas,
+                out failureReason))
             {
                 return false;
             }
@@ -129,6 +160,11 @@ namespace PitmastersGrill.Services
 
         public void ApplySnapshot(AppSettings settings, WindowLayoutSnapshot snapshot)
         {
+            ApplySnapshot(settings, snapshot, WindowLayoutMode.Normal);
+        }
+
+        public void ApplySnapshot(AppSettings settings, WindowLayoutSnapshot snapshot, WindowLayoutMode mode)
+        {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -139,6 +175,23 @@ namespace PitmastersGrill.Services
                 throw new ArgumentNullException(nameof(snapshot));
             }
 
+            if (mode == WindowLayoutMode.Board)
+            {
+                settings.SavedBoardWindowLeft = snapshot.Left;
+                settings.SavedBoardWindowTop = snapshot.Top;
+                settings.SavedBoardWindowWidth = snapshot.Width;
+                settings.SavedBoardWindowHeight = snapshot.Height;
+                settings.SavedBoardWindowIsMaximized = snapshot.IsMaximized;
+                return;
+            }
+
+            settings.SavedNormalWindowLeft = snapshot.Left;
+            settings.SavedNormalWindowTop = snapshot.Top;
+            settings.SavedNormalWindowWidth = snapshot.Width;
+            settings.SavedNormalWindowHeight = snapshot.Height;
+            settings.SavedNormalWindowIsMaximized = snapshot.IsMaximized;
+
+            // Keep legacy fields synchronized so existing code or older settings readers still see the normal layout.
             settings.SavedWindowLeft = snapshot.Left;
             settings.SavedWindowTop = snapshot.Top;
             settings.SavedWindowWidth = snapshot.Width;
@@ -148,10 +201,31 @@ namespace PitmastersGrill.Services
 
         public void ClearSavedLayout(AppSettings settings)
         {
+            ClearSavedLayout(settings, WindowLayoutMode.Normal);
+        }
+
+        public void ClearSavedLayout(AppSettings settings, WindowLayoutMode mode)
+        {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
             }
+
+            if (mode == WindowLayoutMode.Board)
+            {
+                settings.SavedBoardWindowLeft = null;
+                settings.SavedBoardWindowTop = null;
+                settings.SavedBoardWindowWidth = null;
+                settings.SavedBoardWindowHeight = null;
+                settings.SavedBoardWindowIsMaximized = false;
+                return;
+            }
+
+            settings.SavedNormalWindowLeft = null;
+            settings.SavedNormalWindowTop = null;
+            settings.SavedNormalWindowWidth = null;
+            settings.SavedNormalWindowHeight = null;
+            settings.SavedNormalWindowIsMaximized = false;
 
             settings.SavedWindowLeft = null;
             settings.SavedWindowTop = null;
@@ -160,7 +234,18 @@ namespace PitmastersGrill.Services
             settings.SavedWindowIsMaximized = false;
         }
 
+        public void ClearAllSavedLayouts(AppSettings settings)
+        {
+            ClearSavedLayout(settings, WindowLayoutMode.Normal);
+            ClearSavedLayout(settings, WindowLayoutMode.Board);
+        }
+
         public bool TryGetSavedWindowBounds(AppSettings settings, out Rect bounds)
+        {
+            return TryGetSavedWindowBounds(settings, WindowLayoutMode.Normal, out bounds);
+        }
+
+        public bool TryGetSavedWindowBounds(AppSettings settings, WindowLayoutMode mode, out Rect bounds)
         {
             if (settings == null)
             {
@@ -169,21 +254,43 @@ namespace PitmastersGrill.Services
 
             bounds = Rect.Empty;
 
-            if (!settings.SavedWindowLeft.HasValue ||
-                !settings.SavedWindowTop.HasValue ||
-                !settings.SavedWindowWidth.HasValue ||
-                !settings.SavedWindowHeight.HasValue)
+            var left = mode == WindowLayoutMode.Board ? settings.SavedBoardWindowLeft : settings.SavedNormalWindowLeft;
+            var top = mode == WindowLayoutMode.Board ? settings.SavedBoardWindowTop : settings.SavedNormalWindowTop;
+            var width = mode == WindowLayoutMode.Board ? settings.SavedBoardWindowWidth : settings.SavedNormalWindowWidth;
+            var height = mode == WindowLayoutMode.Board ? settings.SavedBoardWindowHeight : settings.SavedNormalWindowHeight;
+
+            if (mode == WindowLayoutMode.Normal &&
+                (!left.HasValue || !top.HasValue || !width.HasValue || !height.HasValue) &&
+                settings.SavedWindowLeft.HasValue &&
+                settings.SavedWindowTop.HasValue &&
+                settings.SavedWindowWidth.HasValue &&
+                settings.SavedWindowHeight.HasValue)
+            {
+                left = settings.SavedWindowLeft;
+                top = settings.SavedWindowTop;
+                width = settings.SavedWindowWidth;
+                height = settings.SavedWindowHeight;
+            }
+
+            if (!left.HasValue || !top.HasValue || !width.HasValue || !height.HasValue)
             {
                 return false;
             }
 
-            bounds = new Rect(
-                settings.SavedWindowLeft.Value,
-                settings.SavedWindowTop.Value,
-                settings.SavedWindowWidth.Value,
-                settings.SavedWindowHeight.Value);
-
+            bounds = new Rect(left.Value, top.Value, width.Value, height.Value);
             return true;
+        }
+
+        public bool IsSavedLayoutMaximized(AppSettings settings, WindowLayoutMode mode)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return mode == WindowLayoutMode.Board
+                ? settings.SavedBoardWindowIsMaximized
+                : settings.SavedNormalWindowIsMaximized || settings.SavedWindowIsMaximized;
         }
 
         public bool TryValidateWindowBounds(
@@ -212,6 +319,7 @@ namespace PitmastersGrill.Services
             foreach (var workArea in workAreas ?? Array.Empty<Rect>())
             {
                 var intersection = Rect.Intersect(bounds, workArea);
+
                 if (!intersection.IsEmpty &&
                     intersection.Width >= minimumVisibleWindowEdge &&
                     intersection.Height >= minimumVisibleWindowEdge)
@@ -232,10 +340,7 @@ namespace PitmastersGrill.Services
             double defaultWindowWidth,
             double defaultWindowHeight)
         {
-            var workArea = workAreas != null && workAreas.Count > 0
-                ? workAreas[0]
-                : new Rect(0, 0, 1280, 800);
-
+            var workArea = workAreas != null && workAreas.Count > 0 ? workAreas[0] : new Rect(0, 0, 1280, 800);
             var width = Math.Max(minimumSavedWindowWidth, defaultWindowWidth);
             var height = Math.Max(minimumSavedWindowHeight, defaultWindowHeight);
 
@@ -251,16 +356,16 @@ namespace PitmastersGrill.Services
         public bool IsUsableWindowBounds(Rect bounds)
         {
             return !bounds.IsEmpty &&
-                   !double.IsNaN(bounds.Left) &&
-                   !double.IsNaN(bounds.Top) &&
-                   !double.IsNaN(bounds.Width) &&
-                   !double.IsNaN(bounds.Height) &&
-                   !double.IsInfinity(bounds.Left) &&
-                   !double.IsInfinity(bounds.Top) &&
-                   !double.IsInfinity(bounds.Width) &&
-                   !double.IsInfinity(bounds.Height) &&
-                   bounds.Width > 0 &&
-                   bounds.Height > 0;
+                !double.IsNaN(bounds.Left) &&
+                !double.IsNaN(bounds.Top) &&
+                !double.IsNaN(bounds.Width) &&
+                !double.IsNaN(bounds.Height) &&
+                !double.IsInfinity(bounds.Left) &&
+                !double.IsInfinity(bounds.Top) &&
+                !double.IsInfinity(bounds.Width) &&
+                !double.IsInfinity(bounds.Height) &&
+                bounds.Width > 0 &&
+                bounds.Height > 0;
         }
 
         public string BuildVirtualDesktopSummary(IReadOnlyList<Rect> workAreas)
@@ -271,6 +376,7 @@ namespace PitmastersGrill.Services
             }
 
             var virtualBounds = workAreas[0];
+
             foreach (var workArea in workAreas.Skip(1))
             {
                 virtualBounds = Rect.Union(virtualBounds, workArea);
@@ -282,7 +388,7 @@ namespace PitmastersGrill.Services
         public string DescribeRect(Rect bounds)
         {
             return bounds.IsEmpty
-                ? "<empty>"
+                ? string.Empty
                 : $"[{bounds.Left:0.##},{bounds.Top:0.##},{bounds.Width:0.##},{bounds.Height:0.##}]";
         }
     }

--- a/SIGNAL-REFERENCE.md
+++ b/SIGNAL-REFERENCE.md
@@ -1,0 +1,43 @@
+# PMG Signal Reference
+
+PMG signal labels are public historical evidence summaries. They are designed to help players interpret copied local lists faster without claiming live certainty.
+
+PMG signals do **not** prove that a pilot is currently in a specific ship, currently fit a certain way, uncloaked, on-grid, or actively baiting.
+
+## Confirmed covert
+
+PMG found recent public killmail-derived module evidence showing a **Covert Cynosural Field Generator I**.
+
+This does not prove the pilot is currently in a covert cyno ship or currently fit that way.
+
+## Confirmed normal
+
+PMG found recent public killmail-derived module evidence showing a regular **Cynosural Field Generator I**.
+
+In the code this is the `normal` cyno type. In one UI/context it may also display as `hard`.
+
+This does not prove the pilot is currently carrying or using a normal cyno.
+
+## Possible
+
+PMG has meaningful evidence, but not enough for recent confirmed module evidence.
+
+This can come from stale or unknown-age module evidence, or from combined weaker signals.
+
+## Inferred
+
+Weak evidence exists, usually from cyno-capable hull observations, public activity, or related context, but no confirmed cyno module was found.
+
+Inferred signals are intentionally weaker than confirmed module evidence.
+
+## Bait
+
+PMG found public loss evidence where an industrial cyno and a tackle module, such as a warp scrambler or warp disruptor, appeared together.
+
+This suggests possible industrial cyno bait, but it is still evidence-based and not proof of intent.
+
+## Required caveat
+
+PMG summarizes public evidence so users can make better decisions. It does not make live-certainty claims.
+
+Use PMG signals as prompts for judgment, not as proof of current ship, fit, location, cloak state, grid state, or intent.


### PR DESCRIPTION
## Summary

Adds the next PMG user-facing clarity and UX sweep.

Includes:
- in-app Help split into General / Getting Started and Signal Reference sections
- public `SIGNAL-REFERENCE.md`
- signal-reference documentation updates in existing docs
- signal reference catalog with tests
- independent Normal and Board mode saved window layouts
- layout controller support for mode-specific restore/save behavior
- tests for mode-specific layout persistence

## Validation

Local validation to run before merge:

- `dotnet restore .\PitmastersGrill\PitmastersGrill.slnx`
- `dotnet build .\PitmastersGrill\PitmastersGrill.slnx --configuration Release --no-restore`
- `dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj --configuration Release --no-build`

## Issues

Closes #26
Closes #27
