### PR TITLE
Improve session context and global hotkeys

### DIFF
--- a/PitmastersGrill.Tests/Ui/MainWindowSessionHotkeyTests.cs
+++ b/PitmastersGrill.Tests/Ui/MainWindowSessionHotkeyTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Ui
+{
+    public sealed class MainWindowSessionHotkeyTests
+    {
+        [Fact]
+        public void MainWindowCode_RegistersGlobalDeleteAndInsertHotkeys()
+        {
+            var code = ReadMainWindowCode();
+
+            Assert.Contains("GlobalClearBoardHotKeyId", code);
+            Assert.Contains("GlobalToggleBoardModeHotKeyId", code);
+            Assert.Contains("Key.Delete", code);
+            Assert.Contains("Key.Insert", code);
+            Assert.Contains("TryRegisterGlobalBoardActionHotKeys", code);
+            Assert.Contains("TryUnregisterGlobalBoardActionHotKeys", code);
+        }
+
+        [Fact]
+        public void MainWindowCode_UsesPendingSessionContextAtStartup()
+        {
+            var code = ReadMainWindowCode();
+
+            Assert.Contains("CreatePendingEveSessionContext", code);
+            Assert.Contains("Waiting for local session evidence", code);
+            Assert.Contains("Soft local read pending", code);
+        }
+
+        [Fact]
+        public void MainWindowCode_DoesNotUseNullableCompactModeValueInDeferredSave()
+        {
+            var code = ReadMainWindowCode();
+
+            Assert.DoesNotContain("previousCompactMode.Value ? WindowLayoutMode.Board", code);
+            Assert.Contains("outgoingLayoutMode", code);
+        }
+
+        [Fact]
+        public void MainWindowXaml_PlacesSessionContextBelowBoardAnalysisDetails()
+        {
+            var xaml = ReadMainWindowXaml();
+
+            var detailsIndex = xaml.IndexOf("AnalysisDetailsPanel", StringComparison.OrdinalIgnoreCase);
+            var sessionIndex = xaml.IndexOf("EVE Session Context", StringComparison.OrdinalIgnoreCase);
+
+            Assert.True(detailsIndex >= 0, "Expected AnalysisDetailsPanel to exist.");
+            Assert.True(sessionIndex >= 0, "Expected EVE Session Context to exist.");
+            Assert.True(
+                sessionIndex > detailsIndex,
+                "Expected EVE Session Context to appear after visible Board Analysis details.");
+        }
+
+        private static string ReadMainWindowCode()
+        {
+            return ReadRepoFile("PitmastersGrill", "MainWindow.xaml.cs");
+        }
+
+        private static string ReadMainWindowXaml()
+        {
+            return ReadRepoFile("PitmastersGrill", "MainWindow.xaml");
+        }
+
+        private static string ReadRepoFile(params string[] relativeParts)
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (current is not null)
+            {
+                var candidateParts = new string[relativeParts.Length + 1];
+                candidateParts[0] = current.FullName;
+                Array.Copy(relativeParts, 0, candidateParts, 1, relativeParts.Length);
+
+                var candidate = Path.Combine(candidateParts);
+
+                if (File.Exists(candidate))
+                {
+                    return File.ReadAllText(candidate);
+                }
+
+                current = current.Parent;
+            }
+
+            throw new FileNotFoundException($"Could not locate repo file: {string.Join("/", relativeParts)}");
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml
+++ b/PitmastersGrill/MainWindow.xaml
@@ -771,95 +771,7 @@
                                   Padding="12"
                                   Background="{DynamicResource WindowBackgroundBrush}">
                         <StackPanel>
-                            <Border Background="{DynamicResource SurfaceAltBrush}"
-                                    BorderBrush="{DynamicResource PanelBorderBrush}"
-                                    BorderThickness="1"
-                                    Padding="16"
-                                    Margin="0,0,0,12">
-                                <StackPanel>
-                                    <TextBlock Text="EVE Session Context"
-                                               FontSize="18"
-                                               FontWeight="SemiBold"
-                                               Foreground="{DynamicResource HeaderTextBrush}"
-                                               Margin="0,0,0,8"/>
-                                    <Grid Margin="0,0,0,4">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="150"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                        </Grid.RowDefinitions>
-
-                                        <TextBlock Grid.Row="0"
-                                                   Grid.Column="0"
-                                                   Foreground="{DynamicResource MutedTextBrush}"
-                                                   Text="Current character"/>
-                                        <TextBlock x:Name="AnalysisCurrentCharacterText"
-                                                   Grid.Row="0"
-                                                   Grid.Column="1"
-                                                   Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,0,0,0"
-                                                   Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not detected"/>
-
-                                        <TextBlock Grid.Row="1"
-                                                   Grid.Column="0"
-                                                   Foreground="{DynamicResource MutedTextBrush}"
-                                                   Text="Current system"/>
-                                        <TextBlock x:Name="AnalysisCurrentSystemText"
-                                                   Grid.Row="1"
-                                                   Grid.Column="1"
-                                                   Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,0,0,0"
-                                                   Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not detected"/>
-
-                                        <TextBlock Grid.Row="2"
-                                                   Grid.Column="0"
-                                                   Foreground="{DynamicResource MutedTextBrush}"
-                                                   Text="Evidence source"/>
-                                        <TextBlock x:Name="AnalysisEvidenceSourceText"
-                                                   Grid.Row="2"
-                                                   Grid.Column="1"
-                                                   Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,0,0,0"
-                                                   Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not configured"/>
-
-                                        <TextBlock Grid.Row="3"
-                                                   Grid.Column="0"
-                                                   Foreground="{DynamicResource MutedTextBrush}"
-                                                   Text="Last observed"/>
-                                        <TextBlock x:Name="AnalysisObservedAtText"
-                                                   Grid.Row="3"
-                                                   Grid.Column="1"
-                                                   Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,0,0,0"
-                                                   Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not detected"/>
-
-                                        <TextBlock Grid.Row="4"
-                                                   Grid.Column="0"
-                                                   Foreground="{DynamicResource MutedTextBrush}"
-                                                   Text="Confidence / status"/>
-                                        <TextBlock x:Name="AnalysisContextStatusText"
-                                                   Grid.Row="4"
-                                                   Grid.Column="1"
-                                                   Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,0,0,0"
-                                                   Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Unable to infer EVE context"/>
-                                    </Grid>
-                                    <TextBlock Style="{StaticResource SettingsLabelStyle}"
-                                               Margin="0,8,0,0"
-                                               Text="Right-click a Grill row to open pilot details. Board Mode keeps the Grill dense for live use; Analysis collects the aggregate readout here."/>
-                                </StackPanel>
-                            </Border>
+                            
 
                             <Border Background="{DynamicResource SurfaceAltBrush}"
                                     BorderBrush="{DynamicResource PanelBorderBrush}"
@@ -950,6 +862,96 @@
                                             </StackPanel>
                                         </Grid>
                                     </StackPanel>
+
+<Border Background="{DynamicResource SurfaceAltBrush}"
+                                    BorderBrush="{DynamicResource PanelBorderBrush}"
+                                    BorderThickness="1"
+                                    Padding="16"
+                                    Margin="0,12,0,0">
+                                <StackPanel>
+                                    <TextBlock Text="EVE Session Context"
+                                               FontSize="18"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource HeaderTextBrush}"
+                                               Margin="0,0,0,8"/>
+                                    <Grid Margin="0,0,0,4">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="150"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock Grid.Row="0"
+                                                   Grid.Column="0"
+                                                   Foreground="{DynamicResource MutedTextBrush}"
+                                                   Text="Current character"/>
+                                        <TextBlock x:Name="AnalysisCurrentCharacterText"
+                                                   Grid.Row="0"
+                                                   Grid.Column="1"
+                                                   Style="{StaticResource SettingsLabelStyle}"
+                                                   Margin="0,0,0,0"
+                                                   Foreground="{DynamicResource BodyTextBrush}"
+                                                   Text="Not detected"/>
+
+                                        <TextBlock Grid.Row="1"
+                                                   Grid.Column="0"
+                                                   Foreground="{DynamicResource MutedTextBrush}"
+                                                   Text="Current system"/>
+                                        <TextBlock x:Name="AnalysisCurrentSystemText"
+                                                   Grid.Row="1"
+                                                   Grid.Column="1"
+                                                   Style="{StaticResource SettingsLabelStyle}"
+                                                   Margin="0,0,0,0"
+                                                   Foreground="{DynamicResource BodyTextBrush}"
+                                                   Text="Not detected"/>
+
+                                        <TextBlock Grid.Row="2"
+                                                   Grid.Column="0"
+                                                   Foreground="{DynamicResource MutedTextBrush}"
+                                                   Text="Evidence source"/>
+                                        <TextBlock x:Name="AnalysisEvidenceSourceText"
+                                                   Grid.Row="2"
+                                                   Grid.Column="1"
+                                                   Style="{StaticResource SettingsLabelStyle}"
+                                                   Margin="0,0,0,0"
+                                                   Foreground="{DynamicResource BodyTextBrush}"
+                                                   Text="Not configured"/>
+
+                                        <TextBlock Grid.Row="3"
+                                                   Grid.Column="0"
+                                                   Foreground="{DynamicResource MutedTextBrush}"
+                                                   Text="Last observed"/>
+                                        <TextBlock x:Name="AnalysisObservedAtText"
+                                                   Grid.Row="3"
+                                                   Grid.Column="1"
+                                                   Style="{StaticResource SettingsLabelStyle}"
+                                                   Margin="0,0,0,0"
+                                                   Foreground="{DynamicResource BodyTextBrush}"
+                                                   Text="Not detected"/>
+
+                                        <TextBlock Grid.Row="4"
+                                                   Grid.Column="0"
+                                                   Foreground="{DynamicResource MutedTextBrush}"
+                                                   Text="Confidence / status"/>
+                                        <TextBlock x:Name="AnalysisContextStatusText"
+                                                   Grid.Row="4"
+                                                   Grid.Column="1"
+                                                   Style="{StaticResource SettingsLabelStyle}"
+                                                   Margin="0,0,0,0"
+                                                   Foreground="{DynamicResource BodyTextBrush}"
+                                                   Text="Unable to infer EVE context"/>
+                                    </Grid>
+                                    <TextBlock Style="{StaticResource SettingsLabelStyle}"
+                                               Margin="0,8,0,0"
+                                               Text="Right-click a Grill row to open pilot details. Board Mode keeps the Grill dense for live use; Analysis collects the aggregate readout here."/>
+                                </StackPanel>
+                            </Border>
                                 </StackPanel>
                             </Border>
                         </StackPanel>

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -42,6 +42,8 @@ namespace PitmastersGrill
         private const int BoardModeHintMilliseconds = 5000;
         private const int TripleEscapeWindowMilliseconds = 1500;
         private const int GlobalResetWindowHotKeyId = 0x504D47;
+        private const int GlobalClearBoardHotKeyId = 0x504D48;
+        private const int GlobalToggleBoardModeHotKeyId = 0x504D49;
         private const double DetailWindowGap = 8;
         private const double NormalModeMinimumWindowWidth = 420;
         private const double NormalModeMinimumWindowHeight = 300;
@@ -119,6 +121,8 @@ namespace PitmastersGrill
         private bool _isBoardColumnAutoFitPending;
         private bool _isBoardColumnLayoutReadyForPersistence;
         private bool _globalResetWindowHotKeyRegistered;
+        private bool _globalClearBoardHotKeyRegistered;
+        private bool _globalToggleBoardModeHotKeyRegistered;
         private EveSessionContext? _currentEveSessionContext;
         private DateTime _lastSessionContextRefreshUtc = DateTime.MinValue;
         private bool _isSessionContextRefreshInFlight;
@@ -276,7 +280,7 @@ namespace PitmastersGrill
             UpdateBoardSummaryBanner();
             UpdateAnalysisTab();
             ApplyIntelUpdateSnapshot(_backgroundIntelUpdateService.GetSnapshot());
-            ApplyEveSessionContext(new EveSessionContext());
+            ApplyEveSessionContext(CreatePendingEveSessionContext());
 
             AppLogger.DatabaseInfo(
                 $"Killmail data path resolved. displayPath={KillmailPaths.GetKillmailDataDirectoryDisplayPath()} source={KillmailPaths.GetKillmailDataDirectorySourceDescription()}");
@@ -299,6 +303,7 @@ namespace PitmastersGrill
             _mainWindowAppearanceController.ApplyTitleBarTheme(this, _appSettings.DarkModeEnabled);
             RestoreWindowLayoutFromSettings();
             TryRegisterGlobalResetWindowHotKey(hwnd);
+            TryRegisterGlobalBoardActionHotKeys(hwnd);
             UpdateWindowStateUi();
             TriggerSessionContextRefresh("startup", force: false);
 
@@ -348,6 +353,7 @@ namespace PitmastersGrill
             _diagnostics.Dispose();
 
             var hwnd = new WindowInteropHelper(this).Handle;
+            TryUnregisterGlobalBoardActionHotKeys(hwnd);
             TryUnregisterGlobalResetWindowHotKey(hwnd);
             RemoveClipboardFormatListener(hwnd);
 
@@ -367,7 +373,7 @@ namespace PitmastersGrill
             ApplyCompactModeUi();
         }
 
-        private void ApplyCompactModeUi() { if (CompactModeToggleButton == null || MainContentGrid == null || TopCommandGrid == null || MainTabControl == null || BoardStatusFooter == null) { return; } var compact = CompactModeToggleButton.IsChecked == true; var previousCompactMode = _lastAppliedCompactMode; var displayModeChanged = !_isApplyingSettings && !_isRestoringWindowLayout && previousCompactMode.HasValue && previousCompactMode.Value != compact; if (displayModeChanged) { SaveWindowLayoutToSettings($"Before display mode change to {(compact ? "Board" : "Normal")}", previousCompactMode.Value ? WindowLayoutMode.Board : WindowLayoutMode.Normal); } _lastAppliedCompactMode = compact; if (compact) { MainTabControl.SelectedIndex = 1; CloseActiveDetailWindow(); } TopCommandGrid.Visibility = compact ? Visibility.Collapsed : Visibility.Visible; TopCommandGrid.Margin = new Thickness(0, 0, 0, 6); BoardStatusFooter.Padding = new Thickness(8, 5, 8, 5); MainContentGrid.Margin = compact ? new Thickness(1) : new Thickness(12); MainTabControl.BorderThickness = compact ? new Thickness(0) : new Thickness(1); MainTabControl.Margin = compact ? new Thickness(0) : new Thickness(0); if (!_isApplyingSettings && _appSettings.CompactModeEnabled != compact) { _appSettings.CompactModeEnabled = compact; _mainWindowAppearanceController.SaveSettings(_appSettings); } if (!_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { AppLogger.UiInfo($"Display mode changed.\nboardMode={compact}"); } if (compact && !_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { ShowBoardModeHint(); } else if (!compact) { HideBoardModeHint(); } UpdateWindowMinimumSize(); if (displayModeChanged) { RestoreWindowLayoutFromSettings(compact ? WindowLayoutMode.Board : WindowLayoutMode.Normal); } UpdateBoardFooterVisibility(); UpdateBoardSummaryBanner(); UpdateAnalysisTab(); } private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void ApplyCompactModeUi() { if (CompactModeToggleButton == null || MainContentGrid == null || TopCommandGrid == null || MainTabControl == null || BoardStatusFooter == null) { return; } var compact = CompactModeToggleButton.IsChecked == true; var previousCompactMode = _lastAppliedCompactMode; var displayModeChanged = !_isApplyingSettings && !_isRestoringWindowLayout && previousCompactMode.HasValue && previousCompactMode.Value != compact; if (displayModeChanged && previousCompactMode.HasValue) { var wasBoardMode = previousCompactMode.GetValueOrDefault(); var outgoingLayoutMode = wasBoardMode ? WindowLayoutMode.Board : WindowLayoutMode.Normal; SaveWindowLayoutToSettings($"Before display mode change to {(compact ? "Board" : "Normal")}", outgoingLayoutMode); } _lastAppliedCompactMode = compact; if (compact) { MainTabControl.SelectedIndex = 1; CloseActiveDetailWindow(); } TopCommandGrid.Visibility = compact ? Visibility.Collapsed : Visibility.Visible; TopCommandGrid.Margin = new Thickness(0, 0, 0, 6); BoardStatusFooter.Padding = new Thickness(8, 5, 8, 5); MainContentGrid.Margin = compact ? new Thickness(1) : new Thickness(12); MainTabControl.BorderThickness = compact ? new Thickness(0) : new Thickness(1); MainTabControl.Margin = compact ? new Thickness(0) : new Thickness(0); if (!_isApplyingSettings && _appSettings.CompactModeEnabled != compact) { _appSettings.CompactModeEnabled = compact; _mainWindowAppearanceController.SaveSettings(_appSettings); } if (!_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { AppLogger.UiInfo($"Display mode changed.\nboardMode={compact}"); } if (compact && !_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { ShowBoardModeHint(); } else if (!compact) { HideBoardModeHint(); } UpdateWindowMinimumSize(); if (displayModeChanged) { RestoreWindowLayoutFromSettings(compact ? WindowLayoutMode.Board : WindowLayoutMode.Normal); } UpdateBoardFooterVisibility(); UpdateBoardSummaryBanner(); UpdateAnalysisTab(); } private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!ReferenceEquals(sender, MainTabControl))
             {
@@ -1850,18 +1856,80 @@ namespace PitmastersGrill
             if (msg == WmClipboardUpdate)
             {
                 ScheduleClipboardProcessing();
+                return IntPtr.Zero;
             }
-            else if (msg == WmHotKey && wParam.ToInt32() == GlobalResetWindowHotKeyId)
-            {
-                handled = true;
 
-                if (!IsActive)
+            if (msg == WmHotKey)
+            {
+                var hotKeyId = wParam.ToInt32();
+
+                switch (hotKeyId)
                 {
-                    RequestWindowLayoutResetFromHotkey("global Ctrl+Home hotkey");
+                    case GlobalResetWindowHotKeyId:
+                        handled = true;
+
+                        if (!IsActive)
+                        {
+                            RequestWindowLayoutResetFromHotkey("global Ctrl+Home hotkey");
+                        }
+
+                        break;
+
+                    case GlobalClearBoardHotKeyId:
+                        handled = true;
+                        ClearBoard("global Delete hotkey");
+                        break;
+
+                    case GlobalToggleBoardModeHotKeyId:
+                        handled = true;
+                        ToggleCompactModeFromHotkey();
+                        break;
+
+                    default:
+                        handled = false;
+                        break;
                 }
             }
 
             return IntPtr.Zero;
+        }
+
+        private void TryRegisterGlobalBoardActionHotKeys(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            _globalClearBoardHotKeyRegistered = RegisterHotKey(
+                hwnd,
+                GlobalClearBoardHotKeyId,
+                0,
+                (uint)KeyInterop.VirtualKeyFromKey(Key.Delete));
+
+            if (_globalClearBoardHotKeyRegistered)
+            {
+                AppLogger.UiInfo("Global Delete clear-board hotkey registered.");
+            }
+            else
+            {
+                AppLogger.UiWarn($"Global Delete clear-board hotkey registration failed. error={Marshal.GetLastWin32Error()}");
+            }
+
+            _globalToggleBoardModeHotKeyRegistered = RegisterHotKey(
+                hwnd,
+                GlobalToggleBoardModeHotKeyId,
+                0,
+                (uint)KeyInterop.VirtualKeyFromKey(Key.Insert));
+
+            if (_globalToggleBoardModeHotKeyRegistered)
+            {
+                AppLogger.UiInfo("Global Insert board-mode hotkey registered.");
+            }
+            else
+            {
+                AppLogger.UiWarn($"Global Insert board-mode hotkey registration failed. error={Marshal.GetLastWin32Error()}");
+            }
         }
 
         private void TryRegisterGlobalResetWindowHotKey(IntPtr hwnd)
@@ -1884,6 +1952,42 @@ namespace PitmastersGrill
             }
 
             AppLogger.UiWarn($"Global Ctrl+Home hotkey registration failed. win32Error={Marshal.GetLastWin32Error()}");
+        }
+
+        private void TryUnregisterGlobalBoardActionHotKeys(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (_globalClearBoardHotKeyRegistered)
+            {
+                if (UnregisterHotKey(hwnd, GlobalClearBoardHotKeyId))
+                {
+                    AppLogger.UiInfo("Global Delete clear-board hotkey unregistered.");
+                }
+                else
+                {
+                    AppLogger.UiWarn($"Global Delete clear-board hotkey unregister failed. error={Marshal.GetLastWin32Error()}");
+                }
+
+                _globalClearBoardHotKeyRegistered = false;
+            }
+
+            if (_globalToggleBoardModeHotKeyRegistered)
+            {
+                if (UnregisterHotKey(hwnd, GlobalToggleBoardModeHotKeyId))
+                {
+                    AppLogger.UiInfo("Global Insert board-mode hotkey unregistered.");
+                }
+                else
+                {
+                    AppLogger.UiWarn($"Global Insert board-mode hotkey unregister failed. error={Marshal.GetLastWin32Error()}");
+                }
+
+                _globalToggleBoardModeHotKeyRegistered = false;
+            }
         }
 
         private void TryUnregisterGlobalResetWindowHotKey(IntPtr hwnd)
@@ -4197,6 +4301,19 @@ namespace PitmastersGrill
             {
                 _isSessionContextRefreshInFlight = false;
             }
+        }
+
+        private static EveSessionContext CreatePendingEveSessionContext()
+        {
+            return new EveSessionContext
+            {
+                CharacterName = "Waiting for local context",
+                SolarSystemName = "Waiting for local context",
+                EvidenceSource = "Soft local read pending",
+                EvidenceTimestampUtc = null,
+                Confidence = "Pending",
+                StatusMessage = "Waiting for local session evidence"
+            };
         }
 
         private void ApplyEveSessionContext(EveSessionContext context)


### PR DESCRIPTION
## Summary

Improves active-session usability and cleans up validation noise.

Includes:
- moves EVE Session Context below the visible Board Analysis details
- uses a pending/waiting local-context state on startup before the soft local read resolves
- registers global Delete hotkey to clear the board
- registers global Insert hotkey to toggle Normal / Board Mode
- unregisters the global board hotkeys on exit
- fixes the nullable compact-mode layout warning path
- adds structure tests for the session context placement and hotkey wiring

## Validation

Local validation to run before merge:

- `dotnet restore .\PitmastersGrill\PitmastersGrill.slnx`
- `dotnet build .\PitmastersGrill\PitmastersGrill.slnx --configuration Release --no-restore`
- `dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj --configuration Release --no-build`

Manual check:

- EVE Session Context appears below Board Analysis
- startup context shows waiting/pending until local session evidence is available
- Delete clears the board globally while PMG is running
- Insert toggles Normal / Board Mode globally while PMG is running
- PMG exits cleanly and unregisters hotkeys

## Issues

Closes #38
Closes #39
Closes #43
