### PR TITLE
Improve public data status visibility

### DIFF
--- a/PitmastersGrill.Tests/Services/PublicDataStatusTextBuilderTests.cs
+++ b/PitmastersGrill.Tests/Services/PublicDataStatusTextBuilderTests.cs
@@ -1,0 +1,91 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class PublicDataStatusTextBuilderTests
+    {
+        [Fact]
+        public void BuildIntelCurrentUpdateStatusText_WhenProviderFails_UsesUncertaintyLanguage()
+        {
+            var snapshot = LoadFixture("provider-failure.json");
+
+            var result = PublicDataStatusTextBuilder.BuildIntelCurrentUpdateStatusText(snapshot);
+
+            Assert.Equal(
+                "Public-data provider check failed. PMG cannot confirm current freshness right now: zKill archive request returned HTTP 503 Service Unavailable",
+                result);
+        }
+
+        [Fact]
+        public void BuildIntelCurrentUpdateStatusText_WhenCoverageIsPartial_ShowsLocalAndRequestedDays()
+        {
+            var snapshot = LoadFixture("partial-coverage.json");
+
+            var result = PublicDataStatusTextBuilder.BuildIntelCurrentUpdateStatusText(snapshot);
+
+            Assert.Equal(
+                "Public data is partially populated. Local coverage is 28 of 30 requested archive day(s); missing 2 day(s).",
+                result);
+        }
+
+        [Fact]
+        public void BuildIntelCurrentUpdateStatusText_WhenCurrent_NamesCompletedArchiveDay()
+        {
+            var snapshot = LoadFixture("current-through-yesterday.json");
+
+            var result = PublicDataStatusTextBuilder.BuildIntelCurrentUpdateStatusText(snapshot);
+
+            Assert.Equal(
+                "Public data archive is current through completed archive day 2026-05-02.",
+                result);
+        }
+
+        [Fact]
+        public void BuildIntelCurrentUpdateStatusText_WhenMissingDays_WarnsAboutStaleOrPartialEvidence()
+        {
+            var snapshot = LoadFixture("missing-days.json");
+
+            var result = PublicDataStatusTextBuilder.BuildIntelCurrentUpdateStatusText(snapshot);
+
+            Assert.Equal(
+                "Public data archive is incomplete. Missing 3 archive day(s); PMG may show stale or partial public evidence until catch-up completes.",
+                result);
+        }
+
+        private static IntelUpdateStatusSnapshot LoadFixture(string fileName)
+        {
+            var fixtureRoot = FindFixtureRoot();
+            var path = Path.Combine(fixtureRoot, "public-data-workflows", fileName);
+            var json = File.ReadAllText(path);
+            var snapshot = JsonSerializer.Deserialize<IntelUpdateStatusSnapshot>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            Assert.NotNull(snapshot);
+            return snapshot!;
+        }
+
+        private static string FindFixtureRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, "test-fixtures");
+                if (Directory.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                directory = directory.Parent;
+            }
+
+            throw new DirectoryNotFoundException("Could not locate test-fixtures directory from test output path.");
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -1789,49 +1789,7 @@ namespace PitmastersGrill
 
         private static string BuildIntelCurrentUpdateStatusText(IntelUpdateStatusSnapshot snapshot)
         {
-            if (snapshot == null)
-            {
-                return "No update currently running.";
-            }
-
-            if (snapshot.HasError)
-            {
-                return string.IsNullOrWhiteSpace(snapshot.ErrorText)
-                    ? "Killmail intel update failed."
-                    : $"Killmail intel update failed: {snapshot.ErrorText}";
-            }
-
-            if (snapshot.IsRunning)
-            {
-                if (snapshot.IsForegroundPriorityActive)
-                {
-                    return "Updating killmail intel is paused for foreground activity.";
-                }
-
-                return string.IsNullOrWhiteSpace(snapshot.CurrentImportDayUtc)
-                    ? "Updating killmail intel…"
-                    : $"Updating killmail intel… Current day {snapshot.CurrentImportDayUtc}.";
-            }
-
-            if (snapshot.HasRequestedCoverageWindow && snapshot.RequestedCoverageDays > 0)
-            {
-                if (!snapshot.IsRequestedCoverageComplete)
-                {
-                    return $"Killmail intel partially populated. Local coverage is {snapshot.LocalCoverageDays} of {snapshot.RequestedCoverageDays} requested days.";
-                }
-            }
-
-            if (snapshot.IsCurrentThroughYesterday)
-            {
-                return "Killmail intel is current.";
-            }
-
-            if (snapshot.MissingDayCount > 0)
-            {
-                return $"Killmail intel is waiting to catch up {snapshot.MissingDayCount} day(s).";
-            }
-
-            return "No update currently running.";
+            return PublicDataStatusTextBuilder.BuildIntelCurrentUpdateStatusText(snapshot);
         }
 
         private static string FormatIntelTimestamp(string value, string emptyText)

--- a/PitmastersGrill/Services/PublicDataStatusTextBuilder.cs
+++ b/PitmastersGrill/Services/PublicDataStatusTextBuilder.cs
@@ -1,0 +1,72 @@
+using PitmastersGrill.Models;
+using System;
+
+namespace PitmastersGrill.Services
+{
+    public static class PublicDataStatusTextBuilder
+    {
+        public static string BuildIntelCurrentUpdateStatusText(IntelUpdateStatusSnapshot? snapshot)
+        {
+            if (snapshot == null)
+            {
+                return "Public-data status is unknown.";
+            }
+
+            if (snapshot.HasError)
+            {
+                var errorText = string.IsNullOrWhiteSpace(snapshot.ErrorText)
+                    ? "provider failure was reported without details"
+                    : snapshot.ErrorText.Trim();
+
+                return $"Public-data provider check failed. PMG cannot confirm current freshness right now: {errorText}";
+            }
+
+            if (snapshot.IsRunning)
+            {
+                if (snapshot.IsForegroundPriorityActive)
+                {
+                    return "Public-data update is paused for foreground activity.";
+                }
+
+                return string.IsNullOrWhiteSpace(snapshot.CurrentImportDayUtc)
+                    ? "Public-data update is running."
+                    : $"Public-data update is running for archive day {snapshot.CurrentImportDayUtc}.";
+            }
+
+            if (snapshot.HasRequestedCoverageWindow && snapshot.RequestedCoverageDays > 0)
+            {
+                if (!snapshot.IsRequestedCoverageComplete)
+                {
+                    var missingText = snapshot.MissingDayCount > 0
+                        ? $"; missing {snapshot.MissingDayCount} day(s)"
+                        : string.Empty;
+
+                    return $"Public data is partially populated. Local coverage is {snapshot.LocalCoverageDays} of {snapshot.RequestedCoverageDays} requested archive day(s){missingText}.";
+                }
+
+                return $"Public data covers the requested {snapshot.RequestedCoverageDays} archive day(s).";
+            }
+
+            if (snapshot.IsCurrentThroughYesterday)
+            {
+                var throughText = string.IsNullOrWhiteSpace(snapshot.RequiredThroughDayUtc)
+                    ? "the latest completed public archive day"
+                    : $"completed archive day {snapshot.RequiredThroughDayUtc}";
+
+                return $"Public data archive is current through {throughText}.";
+            }
+
+            if (snapshot.MissingDayCount > 0)
+            {
+                return $"Public data archive is incomplete. Missing {snapshot.MissingDayCount} archive day(s); PMG may show stale or partial public evidence until catch-up completes.";
+            }
+
+            if (!string.IsNullOrWhiteSpace(snapshot.LatestCompleteDayUtc))
+            {
+                return $"Public data archive is idle. Latest complete local archive day is {snapshot.LatestCompleteDayUtc}.";
+            }
+
+            return "Public-data status is idle. No local archive coverage has been recorded yet.";
+        }
+    }
+}

--- a/test-fixtures/public-data-workflows/current-through-yesterday.json
+++ b/test-fixtures/public-data-workflows/current-through-yesterday.json
@@ -1,0 +1,10 @@
+{
+  "isRunning": false,
+  "isCurrentThroughYesterday": true,
+  "hasError": false,
+  "requiredThroughDayUtc": "2026-05-02",
+  "latestCompleteDayUtc": "2026-05-02",
+  "hasRequestedCoverageWindow": false,
+  "isRequestedCoverageComplete": true,
+  "missingDayCount": 0
+}

--- a/test-fixtures/public-data-workflows/missing-days.json
+++ b/test-fixtures/public-data-workflows/missing-days.json
@@ -1,0 +1,9 @@
+{
+  "isRunning": false,
+  "isCurrentThroughYesterday": false,
+  "hasError": false,
+  "hasRequestedCoverageWindow": false,
+  "latestCompleteDayUtc": "2026-04-29",
+  "requiredThroughDayUtc": "2026-05-02",
+  "missingDayCount": 3
+}

--- a/test-fixtures/public-data-workflows/partial-coverage.json
+++ b/test-fixtures/public-data-workflows/partial-coverage.json
@@ -1,0 +1,12 @@
+{
+  "isRunning": false,
+  "isCurrentThroughYesterday": false,
+  "hasError": false,
+  "hasRequestedCoverageWindow": true,
+  "isRequestedCoverageComplete": false,
+  "requestedCoverageDays": 30,
+  "localCoverageDays": 28,
+  "missingDayCount": 2,
+  "latestCompleteDayUtc": "2026-05-02",
+  "requiredThroughDayUtc": "2026-05-02"
+}

--- a/test-fixtures/public-data-workflows/provider-failure.json
+++ b/test-fixtures/public-data-workflows/provider-failure.json
@@ -1,0 +1,7 @@
+{
+  "isRunning": false,
+  "isCurrentThroughYesterday": false,
+  "hasError": true,
+  "errorText": "zKill archive request returned HTTP 503 Service Unavailable",
+  "missingDayCount": 0
+}


### PR DESCRIPTION
﻿## Summary
- Extracts public-data status wording into a testable service.
- Clarifies public-data freshness, partial coverage, missing days, and provider failure states.
- Adds fixture-based workflow coverage for public-data status behavior.

## Validation
- dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj
- dotnet build .\PitmastersGrill\PitmastersGrill.csproj

## Issues
Closes #32
Closes #29
