### PR TITLE
Extract board summary text builder

### DIFF
--- a/PitmastersGrill.Tests/Services/BoardSummaryTextBuilderTests.cs
+++ b/PitmastersGrill.Tests/Services/BoardSummaryTextBuilderTests.cs
@@ -1,0 +1,82 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System.Collections.Generic;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class BoardSummaryTextBuilderTests
+    {
+        [Fact]
+        public void Build_WithNoRows_ReturnsZeroCounts()
+        {
+            var result = BoardSummaryTextBuilder.Build(new List<PilotBoardRow>());
+
+            Assert.Equal(
+                "Visible 0 | Watched 0 | Bait 0 | Hard Cyno 0 | Covert Cyno 0",
+                result);
+        }
+
+        [Fact]
+        public void Build_WithMixedRows_CountsVisibleWatchedBaitAndCynoKinds()
+        {
+            var rows = new List<PilotBoardRow>
+            {
+                new()
+                {
+                    CharacterName = "Scout One",
+                    IsWatched = true,
+                    BoardSignalKind = "ConfirmedNormal"
+                },
+                new()
+                {
+                    CharacterName = "Scout Two",
+                    HasDerivedBaitEvidence = true,
+                    BoardSignalKind = "ConfirmedCovert"
+                },
+                new()
+                {
+                    CharacterName = "Scout Three",
+                    BaitOverride = true,
+                    BoardSignalKind = "Unknown"
+                },
+                new()
+                {
+                    CharacterName = "Scout Four"
+                }
+            };
+
+            var result = BoardSummaryTextBuilder.Build(rows);
+
+            Assert.Equal(
+                "Visible 4 | Watched 1 | Bait 2 | Hard Cyno 1 | Covert Cyno 1",
+                result);
+        }
+
+        [Fact]
+        public void Build_TreatsSignalKindsCaseInsensitively()
+        {
+            var rows = new List<PilotBoardRow>
+            {
+                new() { BoardSignalKind = "confirmednormal" },
+                new() { BoardSignalKind = "CONFIRMEDCOVERT" }
+            };
+
+            var result = BoardSummaryTextBuilder.Build(rows);
+
+            Assert.Equal(
+                "Visible 2 | Watched 0 | Bait 0 | Hard Cyno 1 | Covert Cyno 1",
+                result);
+        }
+
+        [Fact]
+        public void Build_WithNullRows_ReturnsZeroCounts()
+        {
+            var result = BoardSummaryTextBuilder.Build(null);
+
+            Assert.Equal(
+                "Visible 0 | Watched 0 | Bait 0 | Hard Cyno 0 | Covert Cyno 0",
+                result);
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -4084,22 +4084,7 @@ namespace PitmastersGrill
                 return;
             }
 
-            var visibleRows = _currentRows.ToList();
-            var watchedCount = visibleRows.Count(row => row.IsWatched);
-            var baitCount = visibleRows.Count(row => row.BaitOverride || row.HasDerivedBaitEvidence);
-            var hardCynoCount = visibleRows.Count(row =>
-                string.Equals(row.BoardSignalKind, "ConfirmedNormal", StringComparison.OrdinalIgnoreCase));
-            var covertCynoCount = visibleRows.Count(row =>
-                string.Equals(row.BoardSignalKind, "ConfirmedCovert", StringComparison.OrdinalIgnoreCase));
-
-            BoardSummaryText.Text = string.Join(" | ", new[]
-            {
-                $"Visible {visibleRows.Count}",
-                $"Watched {watchedCount}",
-                $"Bait {baitCount}",
-                $"Hard Cyno {hardCynoCount}",
-                $"Covert Cyno {covertCynoCount}"
-            });
+            BoardSummaryText.Text = BoardSummaryTextBuilder.Build(_currentRows);
         }
 
         private void CurrentRows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/PitmastersGrill/Services/BoardSummaryTextBuilder.cs
+++ b/PitmastersGrill/Services/BoardSummaryTextBuilder.cs
@@ -1,0 +1,34 @@
+using PitmastersGrill.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PitmastersGrill.Services
+{
+    public static class BoardSummaryTextBuilder
+    {
+        public static string Build(IEnumerable<PilotBoardRow>? rows)
+        {
+            var visibleRows = rows?
+                .Where(row => row != null)
+                .ToList()
+                ?? new List<PilotBoardRow>();
+
+            var watchedCount = visibleRows.Count(row => row.IsWatched);
+            var baitCount = visibleRows.Count(row => row.BaitOverride || row.HasDerivedBaitEvidence);
+            var hardCynoCount = visibleRows.Count(row =>
+                string.Equals(row.BoardSignalKind, "ConfirmedNormal", StringComparison.OrdinalIgnoreCase));
+            var covertCynoCount = visibleRows.Count(row =>
+                string.Equals(row.BoardSignalKind, "ConfirmedCovert", StringComparison.OrdinalIgnoreCase));
+
+            return string.Join(" | ", new[]
+            {
+                $"Visible {visibleRows.Count}",
+                $"Watched {watchedCount}",
+                $"Bait {baitCount}",
+                $"Hard Cyno {hardCynoCount}",
+                $"Covert Cyno {covertCynoCount}"
+            });
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Extracts board summary banner text generation from MainWindow into a testable service.
- Adds focused tests for visible, watched, bait, hard cyno, and covert cyno counts.
- Continues MainWindow responsibility extraction without broad UI surgery.

## Validation
- dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj
- dotnet build .\PitmastersGrill\PitmastersGrill.csproj

## Issues
Closes #28
