### PR TITLE
Add update awareness checks

### DIFF
--- a/PitmastersGrill.Tests/Services/ReleaseVersionComparerTests.cs
+++ b/PitmastersGrill.Tests/Services/ReleaseVersionComparerTests.cs
@@ -1,0 +1,92 @@
+using PitmastersGrill.Services;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class ReleaseVersionComparerTests
+    {
+        [Theory]
+        [InlineData("1.2.0", "1.3.0")]
+        [InlineData("v1.2.0", "v1.3.0")]
+        [InlineData("General Release-v1.2.0", "v1.3.0")]
+        public void IsNewerStableVersion_ReturnsTrue_WhenLatestIsNewer(string currentVersion, string latestVersion)
+        {
+            Assert.True(ReleaseVersionComparer.IsNewerStableVersion(currentVersion, latestVersion));
+        }
+
+        [Theory]
+        [InlineData("1.3.0", "1.3.0")]
+        [InlineData("1.3.1", "1.3.0")]
+        [InlineData("1.2.0", "v1.3.0-beta.1")]
+        public void IsNewerStableVersion_ReturnsFalse_WhenLatestIsNotNewerStable(string currentVersion, string latestVersion)
+        {
+            Assert.False(ReleaseVersionComparer.IsNewerStableVersion(currentVersion, latestVersion));
+        }
+
+        [Theory]
+        [InlineData("v1.3.0", "1.3.0")]
+        [InlineData("General Release-v1.3.0", "v1.3.0")]
+        public void IsSameStableVersion_NormalizesKnownPrefixes(string leftVersion, string rightVersion)
+        {
+            Assert.True(ReleaseVersionComparer.IsSameStableVersion(leftVersion, rightVersion));
+        }
+
+        [Fact]
+        public async Task CheckAsync_ReturnsAvailable_WhenLatestStableIsNewer()
+        {
+            var service = new PmgUpdateAwarenessService(
+                new StubLatestReleaseChecker(new GitHubLatestRelease("v1.3.0", "https://example.test/release")),
+                "1.2.0");
+
+            var result = await service.CheckAsync(string.Empty, CancellationToken.None);
+
+            Assert.True(result.IsUpdateAvailable);
+            Assert.Equal("1.2.0", result.CurrentVersion);
+            Assert.Equal("1.3.0", result.LatestVersion);
+            Assert.Equal("https://example.test/release", result.ReleasePageUrl);
+        }
+
+        [Fact]
+        public async Task CheckAsync_RespectsSkippedVersion_ForStartupChecks()
+        {
+            var service = new PmgUpdateAwarenessService(
+                new StubLatestReleaseChecker(new GitHubLatestRelease("v1.3.0", "https://example.test/release")),
+                "1.2.0");
+
+            var result = await service.CheckAsync("v1.3.0", CancellationToken.None);
+
+            Assert.False(result.IsUpdateAvailable);
+            Assert.Equal("1.3.0", result.LatestVersion);
+        }
+
+        [Fact]
+        public async Task CheckAsync_IgnoresSkippedVersion_ForManualChecks()
+        {
+            var service = new PmgUpdateAwarenessService(
+                new StubLatestReleaseChecker(new GitHubLatestRelease("v1.3.0", "https://example.test/release")),
+                "1.2.0");
+
+            var result = await service.CheckAsync("v1.3.0", respectSkippedVersion: false, CancellationToken.None);
+
+            Assert.True(result.IsUpdateAvailable);
+            Assert.Equal("1.3.0", result.LatestVersion);
+        }
+
+        private sealed class StubLatestReleaseChecker : ILatestReleaseChecker
+        {
+            private readonly GitHubLatestRelease? _release;
+
+            public StubLatestReleaseChecker(GitHubLatestRelease? release)
+            {
+                _release = release;
+            }
+
+            public Task<GitHubLatestRelease?> GetLatestStableReleaseAsync(CancellationToken cancellationToken)
+            {
+                return Task.FromResult(_release);
+            }
+        }
+    }
+}

--- a/PitmastersGrill/App.xaml.cs
+++ b/PitmastersGrill/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using PitmastersGrill.Models;
+using PitmastersGrill.Models;
 using PitmastersGrill.Persistence;
 using PitmastersGrill.Providers;
 using PitmastersGrill.Services;
@@ -250,6 +250,95 @@ namespace PitmastersGrill
             }
         }
 
+
+        private async Task RunReleaseUpdateAwarenessCheckAsync(Views.StartupSplashWindow splash)
+        {
+            try
+            {
+                await splash.Dispatcher.InvokeAsync(() =>
+                {
+                    splash.ApplyState(new StartupUpdateState
+                    {
+                        StatusText = "Checking for PMG updates",
+                        DetailText = "Checking the latest stable GitHub release. Startup will continue if this check is unavailable.",
+                        IsIndeterminate = true,
+                        ProgressValue = 0,
+                        IsExceptionMessage = false
+                    });
+                });
+
+                var appSettingsService = new AppSettingsService();
+                var settings = appSettingsService.Load();
+                var currentVersion = GetCurrentApplicationVersionText();
+                var updateService = new PmgUpdateAwarenessService(new GitHubLatestReleaseChecker(), currentVersion);
+                var result = await updateService.CheckAsync(settings.SkippedUpdateVersion, CancellationToken.None);
+
+                if (!result.IsUpdateAvailable)
+                {
+                    return;
+                }
+
+                await splash.Dispatcher.InvokeAsync(() =>
+                {
+                    var message =
+                        $"PMG {result.LatestVersion} is available.\n\n" +
+                        $"Current version: {result.CurrentVersion}\n" +
+                        $"Latest version: {result.LatestVersion}\n\n" +
+                        "Yes: open the GitHub release page for manual update.\n" +
+                        "No: remind me later.\n" +
+                        "Cancel: skip this version.";
+
+                    var response = MessageBox.Show(
+                        splash,
+                        message,
+                        "PMG Update Available",
+                        MessageBoxButton.YesNoCancel,
+                        MessageBoxImage.Information);
+
+                    if (response == MessageBoxResult.Yes)
+                    {
+                        new BrowserLauncher().OpenUrl(result.ReleasePageUrl);
+                    }
+                    else if (response == MessageBoxResult.Cancel)
+                    {
+                        settings.SkippedUpdateVersion = result.LatestVersion;
+                        appSettingsService.Save(settings);
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                AppLogger.AppInfo("PMG release update check failed. Startup will continue.");
+                AppLogger.ErrorOnly("PMG release update check failure.", ex);
+            }
+            finally
+            {
+                try
+                {
+                    await splash.Dispatcher.InvokeAsync(() =>
+                    {
+                        splash.ApplyState(new StartupUpdateState
+                        {
+                            StatusText = "Checking local intel database",
+                            DetailText = "Initializing PMG and reviewing local intel freshness.",
+                            IsIndeterminate = true,
+                            ProgressValue = 0,
+                            IsExceptionMessage = false
+                        });
+                    });
+                }
+                catch
+                {
+                    // Best effort only. Startup should continue even if the splash is closing.
+                }
+            }
+        }
+
+        private static string GetCurrentApplicationVersionText()
+        {
+            return typeof(App).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+        }
+
         private async Task RunNormalStartupAsync()
         {
             AppLogger.AppInfo("Normal startup sequence begin.");
@@ -263,6 +352,7 @@ namespace PitmastersGrill
                 IsExceptionMessage = false
             });
             splash.Show();
+            await RunReleaseUpdateAwarenessCheckAsync(splash);
 
             try
             {

--- a/PitmastersGrill/MainWindow.xaml
+++ b/PitmastersGrill/MainWindow.xaml
@@ -2323,6 +2323,24 @@
                                                     <Run Text="https://github.com/SmokeyForged/Pitmasters-Grill"/>
                                                 </Hyperlink>
                                             </TextBlock>
+
+                        <StackPanel Margin="0,18,0,0">
+                            <TextBlock Text="Updates"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,4" />
+                            <TextBlock Text="Check GitHub for the latest stable PMG release. This does not download, install, or replace files."
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <Button x:Name="ManualUpdateCheckButton"
+                                    Content="Check for Updates"
+                                    Width="150"
+                                    HorizontalAlignment="Left"
+                                    Click="ManualUpdateCheckButton_Click" />
+                            <TextBlock x:Name="ManualUpdateStatusText"
+                                       Text="Manual update check has not run this session."
+                                       TextWrapping="Wrap"
+                                       Margin="0,8,0,0" />
+                        </StackPanel>
                                         </StackPanel>
                                     </Border>
                                 </ScrollViewer>

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -2675,6 +2675,90 @@ namespace PitmastersGrill
             await RunEnableKillmailDbPullAsync();
         }
 
+
+        private async void ManualUpdateCheckButton_Click(object sender, RoutedEventArgs e)
+        {
+            await RunManualUpdateCheckAsync();
+        }
+
+        private async Task RunManualUpdateCheckAsync()
+        {
+            try
+            {
+                ManualUpdateCheckButton.IsEnabled = false;
+                ManualUpdateStatusText.Text = "Checking GitHub for the latest stable PMG release...";
+
+                var appSettingsService = new AppSettingsService();
+                var settings = appSettingsService.Load();
+                var currentVersion = typeof(MainWindow).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+                var updateService = new PmgUpdateAwarenessService(new GitHubLatestReleaseChecker(), currentVersion);
+                var result = await updateService.CheckAsync(
+                    settings.SkippedUpdateVersion,
+                    respectSkippedVersion: false,
+                    _windowShutdownCts.Token);
+
+                if (!result.IsUpdateAvailable)
+                {
+                    ManualUpdateStatusText.Text = $"PMG is current. Current version: {result.CurrentVersion}. Checked {DateTime.Now:g}.";
+                    MessageBox.Show(
+                        this,
+                        $"PMG is current.\n\nCurrent version: {result.CurrentVersion}",
+                        "PMG Update Check",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                    return;
+                }
+
+                ManualUpdateStatusText.Text = $"PMG {result.LatestVersion} is available. Current version: {result.CurrentVersion}. Checked {DateTime.Now:g}.";
+
+                var message =
+                    $"PMG {result.LatestVersion} is available.\n\n" +
+                    $"Current version: {result.CurrentVersion}\n" +
+                    $"Latest version: {result.LatestVersion}\n\n" +
+                    "Yes: open the GitHub release page for manual update.\n" +
+                    "No: leave this reminder available.\n" +
+                    "Cancel: skip this version.";
+
+                var response = MessageBox.Show(
+                    this,
+                    message,
+                    "PMG Update Available",
+                    MessageBoxButton.YesNoCancel,
+                    MessageBoxImage.Information);
+
+                if (response == MessageBoxResult.Yes)
+                {
+                    _browserLauncher.OpenUrl(result.ReleasePageUrl);
+                }
+                else if (response == MessageBoxResult.Cancel)
+                {
+                    settings.SkippedUpdateVersion = result.LatestVersion;
+                    _appSettings.SkippedUpdateVersion = result.LatestVersion;
+                    appSettingsService.Save(settings);
+                    ManualUpdateStatusText.Text = $"Skipped PMG {result.LatestVersion}. Manual checks will still show available releases.";
+                }
+            }
+            catch (OperationCanceledException) when (_isShuttingDown || _windowShutdownCts.IsCancellationRequested)
+            {
+                ManualUpdateStatusText.Text = "Update check cancelled.";
+            }
+            catch (Exception ex)
+            {
+                AppLogger.UiError("Manual update check failed.", ex);
+                ManualUpdateStatusText.Text = $"Update check failed: {ex.Message}";
+                MessageBox.Show(
+                    this,
+                    $"PMG could not check for updates.\n\n{ex.Message}",
+                    "PMG Update Check",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+            }
+            finally
+            {
+                ManualUpdateCheckButton.IsEnabled = true;
+            }
+        }
+
         private void OpenLogsButton_Click(object sender, RoutedEventArgs e)
         {
             try

--- a/PitmastersGrill/Models/AppSettings.cs
+++ b/PitmastersGrill/Models/AppSettings.cs
@@ -99,6 +99,8 @@ namespace PitmastersGrill.Models
 
         public List<BoardColumnLayoutSetting> BoardColumnLayout { get; set; } = new();
 
+        public string SkippedUpdateVersion { get; set; } = string.Empty;
+
         public AppLogLevel LogLevel { get; set; } = AppLogLevel.Normal;
     }
 }

--- a/PitmastersGrill/Services/GitHubLatestReleaseChecker.cs
+++ b/PitmastersGrill/Services/GitHubLatestReleaseChecker.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class GitHubLatestRelease
+    {
+        public GitHubLatestRelease(string version, string releasePageUrl)
+        {
+            Version = version;
+            ReleasePageUrl = releasePageUrl;
+        }
+
+        public string Version { get; }
+
+        public string ReleasePageUrl { get; }
+    }
+
+    public interface ILatestReleaseChecker
+    {
+        Task<GitHubLatestRelease?> GetLatestStableReleaseAsync(CancellationToken cancellationToken);
+    }
+
+    public sealed class GitHubLatestReleaseChecker : ILatestReleaseChecker
+    {
+        private static readonly Uri LatestReleaseUri = new("https://api.github.com/repos/SmokeyForged/Pitmasters-Grill/releases/latest");
+
+        public async Task<GitHubLatestRelease?> GetLatestStableReleaseAsync(CancellationToken cancellationToken)
+        {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("Pitmasters-Grill");
+
+            using var response = await client.GetAsync(LatestReleaseUri, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var root = document.RootElement;
+
+            if (TryGetBoolean(root, "draft") || TryGetBoolean(root, "prerelease"))
+            {
+                return null;
+            }
+
+            var tagName = TryGetString(root, "tag_name");
+            var releasePageUrl = TryGetString(root, "html_url");
+            var stableVersion = ReleaseVersionComparer.NormalizeStableVersionText(tagName);
+
+            if (string.IsNullOrWhiteSpace(stableVersion) || string.IsNullOrWhiteSpace(releasePageUrl))
+            {
+                return null;
+            }
+
+            return new GitHubLatestRelease(stableVersion, releasePageUrl);
+        }
+
+        private static string TryGetString(JsonElement root, string propertyName)
+        {
+            return root.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+                ? property.GetString() ?? string.Empty
+                : string.Empty;
+        }
+
+        private static bool TryGetBoolean(JsonElement root, string propertyName)
+        {
+            return root.TryGetProperty(propertyName, out var property)
+                && property.ValueKind == JsonValueKind.True;
+        }
+    }
+}

--- a/PitmastersGrill/Services/PmgUpdateAwarenessService.cs
+++ b/PitmastersGrill/Services/PmgUpdateAwarenessService.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class PmgUpdateAwarenessResult
+    {
+        private PmgUpdateAwarenessResult(
+            bool isUpdateAvailable,
+            string currentVersion,
+            string latestVersion,
+            string releasePageUrl,
+            string statusText)
+        {
+            IsUpdateAvailable = isUpdateAvailable;
+            CurrentVersion = currentVersion;
+            LatestVersion = latestVersion;
+            ReleasePageUrl = releasePageUrl;
+            StatusText = statusText;
+        }
+
+        public bool IsUpdateAvailable { get; }
+
+        public string CurrentVersion { get; }
+
+        public string LatestVersion { get; }
+
+        public string ReleasePageUrl { get; }
+
+        public string StatusText { get; }
+
+        public static PmgUpdateAwarenessResult Current(string currentVersion)
+        {
+            return new PmgUpdateAwarenessResult(false, currentVersion, string.Empty, string.Empty, "PMG is current.");
+        }
+
+        public static PmgUpdateAwarenessResult Skipped(string currentVersion, string latestVersion)
+        {
+            return new PmgUpdateAwarenessResult(false, currentVersion, latestVersion, string.Empty, $"PMG {latestVersion} was skipped.");
+        }
+
+        public static PmgUpdateAwarenessResult Available(string currentVersion, string latestVersion, string releasePageUrl)
+        {
+            return new PmgUpdateAwarenessResult(true, currentVersion, latestVersion, releasePageUrl, $"PMG {latestVersion} is available.");
+        }
+    }
+
+    public sealed class PmgUpdateAwarenessService
+    {
+        private readonly ILatestReleaseChecker _latestReleaseChecker;
+        private readonly string _currentVersion;
+
+        public PmgUpdateAwarenessService(ILatestReleaseChecker latestReleaseChecker, string currentVersion)
+        {
+            _latestReleaseChecker = latestReleaseChecker ?? throw new ArgumentNullException(nameof(latestReleaseChecker));
+            _currentVersion = ReleaseVersionComparer.NormalizeStableVersionText(currentVersion);
+
+            if (string.IsNullOrWhiteSpace(_currentVersion))
+            {
+                _currentVersion = "0.0.0";
+            }
+        }
+
+        public Task<PmgUpdateAwarenessResult> CheckAsync(string? skippedUpdateVersion, CancellationToken cancellationToken)
+        {
+            return CheckAsync(skippedUpdateVersion, respectSkippedVersion: true, cancellationToken);
+        }
+
+        public async Task<PmgUpdateAwarenessResult> CheckAsync(
+            string? skippedUpdateVersion,
+            bool respectSkippedVersion,
+            CancellationToken cancellationToken)
+        {
+            var latestRelease = await _latestReleaseChecker.GetLatestStableReleaseAsync(cancellationToken).ConfigureAwait(false);
+            if (latestRelease == null)
+            {
+                return PmgUpdateAwarenessResult.Current(_currentVersion);
+            }
+
+            var latestVersion = ReleaseVersionComparer.NormalizeStableVersionText(latestRelease.Version);
+            if (string.IsNullOrWhiteSpace(latestVersion))
+            {
+                return PmgUpdateAwarenessResult.Current(_currentVersion);
+            }
+
+            if (!ReleaseVersionComparer.IsNewerStableVersion(_currentVersion, latestVersion))
+            {
+                return PmgUpdateAwarenessResult.Current(_currentVersion);
+            }
+
+            if (respectSkippedVersion
+                && ReleaseVersionComparer.IsSameStableVersion(skippedUpdateVersion, latestVersion))
+            {
+                return PmgUpdateAwarenessResult.Skipped(_currentVersion, latestVersion);
+            }
+
+            return PmgUpdateAwarenessResult.Available(
+                _currentVersion,
+                latestVersion,
+                latestRelease.ReleasePageUrl);
+        }
+    }
+}

--- a/PitmastersGrill/Services/ReleaseVersionComparer.cs
+++ b/PitmastersGrill/Services/ReleaseVersionComparer.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace PitmastersGrill.Services
+{
+    public static class ReleaseVersionComparer
+    {
+        public static bool IsNewerStableVersion(string? currentVersionText, string? latestVersionText)
+        {
+            if (!TryParseStableVersion(latestVersionText, out var latestVersion))
+            {
+                return false;
+            }
+
+            if (!TryParseStableVersion(currentVersionText, out var currentVersion))
+            {
+                currentVersion = new Version(0, 0, 0);
+            }
+
+            return latestVersion.CompareTo(currentVersion) > 0;
+        }
+
+        public static bool IsSameStableVersion(string? leftVersionText, string? rightVersionText)
+        {
+            return TryParseStableVersion(leftVersionText, out var leftVersion)
+                && TryParseStableVersion(rightVersionText, out var rightVersion)
+                && leftVersion.CompareTo(rightVersion) == 0;
+        }
+
+        public static string NormalizeStableVersionText(string? versionText)
+        {
+            return TryParseStableVersion(versionText, out var version)
+                ? version.ToString(3)
+                : string.Empty;
+        }
+
+        private static bool TryParseStableVersion(string? versionText, out Version version)
+        {
+            version = new Version(0, 0, 0);
+
+            if (string.IsNullOrWhiteSpace(versionText))
+            {
+                return false;
+            }
+
+            var normalized = versionText.Trim();
+
+            if (normalized.StartsWith("General Release-", StringComparison.OrdinalIgnoreCase))
+            {
+                normalized = normalized["General Release-".Length..];
+            }
+
+            normalized = normalized.TrimStart('v', 'V').Trim();
+
+            if (normalized.Contains('-', StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var match = Regex.Match(normalized, @"^(\d+)\.(\d+)\.(\d+)$");
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            version = new Version(
+                int.Parse(match.Groups[1].Value),
+                int.Parse(match.Groups[2].Value),
+                int.Parse(match.Groups[3].Value));
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Adds startup/splash update awareness for the latest stable PMG GitHub release.
- Adds a manual Settings > Version update checker for validating the release-check pipeline without restarting.
- Supports skipped-version suppression for startup checks while keeping manual checks available.
- Keeps v1.3.0 updater behavior awareness-only: no download, install, replacement, restart, or rollback automation.

## Validation
- dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj
- dotnet build .\PitmastersGrill\PitmastersGrill.csproj
- Runtime smoke: splash update check runs and startup continues
- Runtime smoke: Settings > Version manual checker reports current version

## Issues
Closes #33
