### PR TITLE
Sync docs for v1.3.0 release

### DIFF
--- a/DEVELOPER-NOTES.md
+++ b/DEVELOPER-NOTES.md
@@ -91,14 +91,22 @@ Startup should prioritize user-visible readiness.
 Expected pattern:
 
 1. show splash/startup flow
-2. initialize core services safely
-3. show main window
-4. schedule background work after UI render
-5. avoid blocking UI thread with network/database work
+2. run optional fail-open release awareness checks without blocking startup
+3. initialize core services safely
+4. show main window
+5. schedule background work after UI render
+6. avoid blocking UI thread with network/database work
 
 Background Historical Repair and live feed behavior should not run inside constructors or `InitializeComponent`.
 
 ---
+
+## Update Awareness
+Update awareness is intentionally not a full self-updater.
+
+Startup and Settings -> Version may check GitHub for the latest stable PMG release. These checks must remain fail-open, cancellable where practical, and user-confirmed before opening a browser. They must not download release assets, replace executable files, restart PMG, or introduce rollback behavior unless a future release explicitly scopes and tests a real updater.
+
+Manual checks should be able to verify the release-check pipeline even when a startup prompt was skipped for a specific version.
 
 ## Freshness Model
 
@@ -358,6 +366,8 @@ Before release:
 - Background Historical Repair does not block startup
 - R2Z2 remains disabled by default
 - diagnostics export works
+- Settings -> Version update check works or fails with a clear message
+- startup update awareness continues if GitHub/network is unavailable
 - README/docs match release
 - patch notes exist
 - version metadata is correct

--- a/FIRST-TIME-USE.md
+++ b/FIRST-TIME-USE.md
@@ -58,6 +58,8 @@ PitmastersGrill.exe
 
 On first launch, PMG may create local app data and prepare its local public-intel cache.
 
+PMG may also check GitHub for the latest stable PMG release during startup. This check is informational and fail-open: if GitHub or the network is unavailable, PMG continues launching. PMG does not automatically download, install, replace files, or restart itself.
+
 If Windows SmartScreen appears, review the prompt and choose the option appropriate for your own trust decision.
 
 ---
@@ -264,8 +266,9 @@ After installing PMG:
 5. Open Intel.
 6. Run Today’s Freshness.
 7. Export diagnostics.
-8. Close and reopen PMG.
-9. Confirm layout and settings persist.
+8. Open Settings -> Version and run Check for Updates.
+9. Close and reopen PMG.
+10. Confirm layout and settings persist.
 
 ---
 

--- a/HOW-IT-WORKS.md
+++ b/HOW-IT-WORKS.md
@@ -206,6 +206,13 @@ This avoids double-counting and keeps freshness repair separate from archive-day
 
 ---
 
+## Update Awareness
+PMG includes an awareness-only release check. During startup, PMG can query GitHub for the latest stable release and then continue startup whether the check succeeds or fails.
+
+The same release-check pipeline is available manually from Settings -> Version. Manual checks ignore skipped-version suppression so maintainers and users can verify the pipeline without restarting.
+
+The update-awareness path does not use EVE data, private ESI scopes, client integration, or gameplay automation. It does not download, install, replace files, restart PMG, or perform rollback logic.
+
 ## Write Coordination
 
 PMG has multiple possible writers to the local killmail database:

--- a/HOW-TO-NAVIGATE-THIS-REPO.md
+++ b/HOW-TO-NAVIGATE-THIS-REPO.md
@@ -16,6 +16,7 @@ If you are new to the repo, start with these files:
 | `PitmastersGrill/` | Main application source code. |
 | `PitmastersGrill.Tests/` | Deterministic non-UI automated test project. |
 | `.github/workflows/` | Windows build/test CI workflow definitions. |
+| `docs/` | Release checklist, dependency maintenance, and supporting maintainer docs. |
 | `Patch Notes/` | Version-by-version release notes. |
 | `PMG-FEATURES.md` | Current feature overview and limitations. |
 | `HOW-IT-WORKS.md` | Technical overview of PMG's data flow and evidence model. |
@@ -37,6 +38,7 @@ Pitmasters-Grill/
 +-- EVE-TOS-COMPLIANCE.md
 +-- DEVELOPER-NOTES.md
 +-- .github/workflows/
++-- docs/
 +-- Patch Notes/
 +-- PitmastersGrill/
 +-- PitmastersGrill.Tests/
@@ -244,12 +246,29 @@ The README should stay short and navigational. Detailed release history belongs 
 Current General Release notes should use a filename similar to:
 
 ```text
-Patch Notes/General-Release_1-2-0.md
+Patch Notes/General-Release_1-3-0.md
 ```
 
 Release-preparation or foundation notes should be promoted into the matching General Release note before public release.
 
 ---
+
+## Update Awareness and Version Checking
+Release-awareness code lives in the main application service layer and startup/UI wiring.
+
+Relevant code areas may include:
+
+```text
+PitmastersGrill/App.xaml.cs
+PitmastersGrill/MainWindow.xaml
+PitmastersGrill/MainWindow.xaml.cs
+PitmastersGrill/Services/GitHubLatestReleaseChecker.cs
+PitmastersGrill/Services/PmgUpdateAwarenessService.cs
+PitmastersGrill/Services/ReleaseVersionComparer.cs
+PitmastersGrill/Models/AppSettings.cs
+```
+
+The feature is awareness-only. It checks GitHub for stable releases, can open the release page, and must not self-install or replace files.
 
 ## Public Data Boundaries
 

--- a/PMG-FEATURES.md
+++ b/PMG-FEATURES.md
@@ -28,6 +28,7 @@ PMG provides:
 - optional R2Z2 live zKill feed
 - zKill open-link workflows
 - diagnostics bundle export
+- release/update awareness and manual version checking
 - saved window and board layout behavior
 - PMG themes
 - tray icon support
@@ -330,6 +331,11 @@ Users should still review diagnostics before posting them publicly.
 
 ---
 
+## Update Awareness
+PMG includes safe release-awareness checks. During startup, PMG may check GitHub for the latest stable release and continue normally if the check is unavailable.
+
+Users can also run a manual check from Settings -> Version. The update checker is informational only: it does not download, install, replace files, restart PMG, or force users onto a newer version. When a newer stable release is available, PMG can open the GitHub release page for manual review and update.
+
 ## Branding and App Integration
 
 PMG includes:
@@ -437,7 +443,7 @@ PMG is in General Release.
 
 Current release:
 
-- **Pitmasters Grill v1.1.0**
+- **Pitmasters Grill v1.3.0**
 - General Release
 - Windows desktop application
 

--- a/Patch Notes/readme.md
+++ b/Patch Notes/readme.md
@@ -11,19 +11,19 @@ Use patch notes for version-by-version release history. Keep the main `README.md
 Current General Release:
 
 ```text
-Pitmasters Grill v1.2.0
+Pitmasters Grill v1.3.0
 ```
 
 Release page:
 
 ```text
-https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.2.0
+https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.3.0
 ```
 
 Current release notes:
 
 ```text
-General-Release_1-2-0.md
+General-Release_1-3-0.md
 ```
 
 ---
@@ -35,7 +35,7 @@ Use clear release-stage filenames.
 Examples:
 
 ```text
-General-Release_1-2-0.md
+General-Release_1-3-0.md
 General-Release_1-1-0.md
 Technical-Preview_0.9.5.1_patch_notes.md
 Technical-Preview_0.9.4_patch_notes.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pitmaster's Grill
+﻿# Pitmaster's Grill
 
 <p align="center">
   <img src="./PitmastersGrill/Assets/AppIcon.png" alt="Pitmaster's Grill icon" width="120" />
@@ -29,11 +29,11 @@ PMG is now in **General Release**.
 
 ---
 
-Current release: **Pitmasters Grill v1.2.0**  
-Latest release: **[v1.2.0 General Release](https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.2.0)**  
+Current release: **Pitmasters Grill v1.3.0**
+Latest release: **[v1.3.0 General Release](https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.3.0)**
 Full release history: **[GitHub Releases](https://github.com/SmokeyForged/Pitmasters-Grill/releases)**
 
-Repository status on `main`: **1.2.0 general release foundation and support improvements are present**. This release focuses on maintainability, automated validation, and safer future iteration. It does **not** add new EVE intel sources or change PMG's public-data boundaries.
+Repository status on `main`: **1.3.0 general release clarity, supportability, UI polish, and update-awareness improvements are present**. This release improves signal/public-data explanation, release readiness, and safe update awareness. It does **not** add new EVE intel sources, private data access, gameplay automation, or automatic self-install behavior.
 
 ---
 
@@ -68,6 +68,7 @@ PMG can:
 - optionally use R2Z2 for live zKill-known killmail ingestion
 - cache public intel locally to reduce repeated lookup cost
 - export diagnostics for troubleshooting
+- check for newer stable PMG releases without downloading, installing, replacing files, or restarting
 - open zKill for deeper manual review
 
 PMG does **not** read EVE client memory, inspect network traffic, automate gameplay, use private ESI character data, or claim live grid/location/cloak certainty.
@@ -78,12 +79,12 @@ PMG does **not** read EVE client memory, inspect network traffic, automate gamep
 
 PMG is organized around a few top-level tabs:
 
-- **Analysis** — summary view for the current visible board.
-- **Grill** — the main pilot board.
-- **Intel** — killmail intel status, freshness tools, R2Z2, diagnostics, and cache controls.
-- **Ignore List** — manage ignored pilots, corporations, and alliances.
-- **Settings** — app behavior, PMG themes, visibility, and layout options.
-- **Help** — shortcut and workflow reference.
+- **Analysis** â€” summary view for the current visible board.
+- **Grill** â€” the main pilot board.
+- **Intel** â€” killmail intel status, freshness tools, R2Z2, diagnostics, and cache controls.
+- **Ignore List** â€” manage ignored pilots, corporations, and alliances.
+- **Settings** â€” app behavior, PMG themes, visibility, layout options, and manual version/update checks.
+- **Help** â€” shortcut and workflow reference.
 
 ---
 
@@ -123,8 +124,8 @@ New here? Start with:
 - **[Patch Notes](./Patch%20Notes/)**  
   Full release history and version notes.
 
-- **[1.2.0 General Release Notes](./Patch%20Notes/General-Release_1-2-0.md)**  
-  Summary of the 1.2.0 support, maintainability, CI, and validation work.
+- **[1.3.0 General Release Notes](./Patch%20Notes/General-Release_1-3-0.md)**
+  Summary of the 1.3.0 clarity, supportability, UI polish, release-readiness, and update-awareness work.
 
 - **[Current Feature Snapshot](./PMG-FEATURES.md)**  
   A deeper overview of PMG's current feature set and limitations.

--- a/WINDOWS-PUBLISHING-TRUST.md
+++ b/WINDOWS-PUBLISHING-TRUST.md
@@ -95,6 +95,11 @@ Main operational risks:
 
 PMG should keep all signing credentials out of source control and out of developer worktrees.
 
+## Update Awareness Does Not Change Windows Trust
+PMG's update-awareness checks do not change Windows publishing trust. Checking GitHub for a newer stable release is not the same as signing, installing, or verifying a downloaded executable.
+
+PMG does not automatically download, install, replace files, restart itself, or bypass SmartScreen. Users still manually download release artifacts from GitHub and make their own Windows trust decision unless a future signed/packaged distribution path is explicitly implemented.
+
 ## Recommended short-term path
 
 Short term, the best PMG path is:

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -13,6 +13,7 @@ This checklist does not replace judgment. It gives the release owner a consisten
 - [ ] Confirm README current-release references are correct.
 - [ ] Confirm patch notes exist for the release.
 - [ ] Confirm release notes accurately describe PMG's public-data boundaries.
+- [ ] Confirm update-awareness wording is accurate and does not imply auto-install behavior.
 - [ ] Confirm the release does not imply live grid, cloak, private ESI, client-memory, or network-traffic certainty.
 
 ## Local validation
@@ -54,6 +55,8 @@ Use a clean local folder when practical.
 - [ ] Confirm Analysis still renders.
 - [ ] Confirm Settings opens.
 - [ ] Confirm Help opens.
+- [ ] Confirm Settings -> Version manual update check reports current/latest status or fails clearly.
+- [ ] Confirm startup update awareness does not block launch if GitHub/network access is unavailable.
 - [ ] Confirm diagnostics export still works.
 - [ ] Confirm diagnostics do not expose unwanted local/private data.
 - [ ] Confirm double-click / zKill-open behavior still works where available.


### PR DESCRIPTION
﻿## Summary
- Syncs public docs for the v1.3.0 release.
- Updates current-release references from v1.2.0/v1.1.0 to v1.3.0 where appropriate.
- Documents update-awareness behavior, including startup checks, Settings > Version manual checks, and the no-auto-install boundary.
- Updates release checklist, repo navigation, feature overview, first-time-use, technical, developer, and Windows trust docs.

## Validation
- Stale current-reference scan returned no matches for targeted v1.2.0/v1.1.0 current-release references.
- git --no-pager diff --check
- Working tree clean after commit.

## Notes
- Historical patch note files retain their original version numbers.
- This is documentation-only.
