### PR TITLE
Sync version metadata for v1.3.0 release

### DIFF
--- a/PitmastersGrill/App.xaml.cs
+++ b/PitmastersGrill/App.xaml.cs
@@ -19,7 +19,7 @@ namespace PitmastersGrill
             base.OnStartup(e);
 
             RegisterGlobalExceptionLogging();
-            AppLogger.Initialize("General Release-v1.2.0", e.Args);
+            AppLogger.Initialize("General Release-v1.3.0", e.Args);
             AppLogger.AppInfo("Application startup invoked.");
 
             try

--- a/PitmastersGrill/MainWindow.xaml
+++ b/PitmastersGrill/MainWindow.xaml
@@ -2035,7 +2035,7 @@
                                                        FontSize="12"
                                                        Margin="24,0,0,14"
                                                        Visibility="Collapsed"
-                                                       Text="Panel Mode is always enabled for PMG 1.2.0."/>
+                                                       Text="Panel Mode is always enabled for PMG 1.3.0."/>
 
                                             <TextBlock Text="Window Surface Opacity"
                                                        Foreground="{DynamicResource BodyTextBrush}"
@@ -2309,7 +2309,7 @@
                                                        Margin="0,0,0,12"/>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
-                                                       Text="General Release-v1.2.0"/>
+                                                       Text="General Release-v1.3.0"/>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                                        Margin="0,4,0,0"

--- a/PitmastersGrill/Persistence/DiagnosticBundleService.cs
+++ b/PitmastersGrill/Persistence/DiagnosticBundleService.cs
@@ -10,7 +10,7 @@ namespace PitmastersGrill.Persistence
 {
     public static class DiagnosticBundleService
     {
-        private const string VersionLabel = "General Release-v1.2.0";
+        private const string VersionLabel = "General Release-v1.3.0";
         private const int MaximumBundlesToRetain = 20;
 
         public static string GetDiagnosticsDirectory()

--- a/PitmastersGrill/PitmastersGrill.csproj
+++ b/PitmastersGrill/PitmastersGrill.csproj
@@ -8,10 +8,10 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
-    <Version>1.2.0</Version>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <InformationalVersion>1.2.0</InformationalVersion>
+    <Version>1.3.0</Version>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
+    <InformationalVersion>1.3.0</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PitmastersGrill/Services/AppHttpDefaults.cs
+++ b/PitmastersGrill/Services/AppHttpDefaults.cs
@@ -2,6 +2,6 @@ namespace PitmastersGrill.Services
 {
     public static class AppHttpDefaults
     {
-        public const string GenericUserAgent = "PitmastersGrill/1.2.0";
+        public const string GenericUserAgent = "PitmastersGrill/1.3.0";
     }
 }


### PR DESCRIPTION
﻿## Summary
- Syncs app-visible and package version metadata from v1.2.0 to v1.3.0.
- Updates logger/diagnostic version labels, Settings > Version text, project version metadata, and PMG HTTP user agent.
- Keeps this PR limited to release metadata only.

## Validation
- dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj
- dotnet build .\PitmastersGrill\PitmastersGrill.csproj
- Stale v1.2.0 metadata scan
- git --no-pager diff --check
