### PR TITLE
Centralize release version metadata

### DIFF
--- a/DEVELOPER-NOTES.md
+++ b/DEVELOPER-NOTES.md
@@ -101,6 +101,17 @@ Background Historical Repair and live feed behavior should not run inside constr
 
 ---
 
+## Release Version Metadata
+App-visible release/version metadata should flow through one path:
+
+```text
+PitmastersGrill/PitmastersGrill.csproj -> PmgReleaseVersion -> AppReleaseMetadata
+```
+
+`PmgReleaseVersion` is the release value to bump. `AppReleaseMetadata` builds the release label, user agent, and user-visible version text from compiled assembly metadata. Avoid adding new hard-coded release strings in UI, logging, diagnostics, or HTTP defaults.
+
+---
+
 ## Update Awareness
 Update awareness is intentionally not a full self-updater.
 

--- a/PitmastersGrill.Tests/Services/AppReleaseMetadataTests.cs
+++ b/PitmastersGrill.Tests/Services/AppReleaseMetadataTests.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+using PitmastersGrill.Services;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public class AppReleaseMetadataTests
+    {
+        [Fact]
+        public void VersionText_IsStableSemanticVersionText()
+        {
+            Assert.Matches(new Regex("^\\d+\\.\\d+\\.\\d+$"), AppReleaseMetadata.VersionText);
+        }
+
+        [Fact]
+        public void ReleaseLabel_UsesCentralVersionText()
+        {
+            Assert.Equal($"{AppReleaseMetadata.ReleaseStage}-v{AppReleaseMetadata.VersionText}", AppReleaseMetadata.ReleaseLabel);
+        }
+
+        [Fact]
+        public void GenericUserAgent_UsesCentralVersionText()
+        {
+            Assert.Equal($"{AppReleaseMetadata.ProductUserAgentName}/{AppReleaseMetadata.VersionText}", AppReleaseMetadata.GenericUserAgent);
+        }
+
+        [Fact]
+        public void PanelModeText_UsesCentralVersionText()
+        {
+            Assert.Equal($"Panel Mode is always enabled for PMG {AppReleaseMetadata.VersionText}.", AppReleaseMetadata.PanelModeAlwaysEnabledText);
+        }
+    }
+}

--- a/PitmastersGrill/App.xaml.cs
+++ b/PitmastersGrill/App.xaml.cs
@@ -19,7 +19,7 @@ namespace PitmastersGrill
             base.OnStartup(e);
 
             RegisterGlobalExceptionLogging();
-            AppLogger.Initialize("General Release-v1.3.0", e.Args);
+            AppLogger.Initialize(AppReleaseMetadata.ReleaseLabel, e.Args);
             AppLogger.AppInfo("Application startup invoked.");
 
             try

--- a/PitmastersGrill/MainWindow.xaml
+++ b/PitmastersGrill/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:PitmastersGrill"
+        xmlns:services="clr-namespace:PitmastersGrill.Services"
         xmlns:views="clr-namespace:PitmastersGrill.Views"
         mc:Ignorable="d"
         Title="Pitmasters Grill"
@@ -2035,7 +2036,7 @@
                                                        FontSize="12"
                                                        Margin="24,0,0,14"
                                                        Visibility="Collapsed"
-                                                       Text="Panel Mode is always enabled for PMG 1.3.0."/>
+                                                       Text="{x:Static services:AppReleaseMetadata.PanelModeAlwaysEnabledText}"/>
 
                                             <TextBlock Text="Window Surface Opacity"
                                                        Foreground="{DynamicResource BodyTextBrush}"
@@ -2309,7 +2310,7 @@
                                                        Margin="0,0,0,12"/>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
-                                                       Text="General Release-v1.3.0"/>
+                                                       Text="{x:Static services:AppReleaseMetadata.ReleaseLabel}"/>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                                        Margin="0,4,0,0"

--- a/PitmastersGrill/Persistence/DiagnosticBundleService.cs
+++ b/PitmastersGrill/Persistence/DiagnosticBundleService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -10,7 +10,7 @@ namespace PitmastersGrill.Persistence
 {
     public static class DiagnosticBundleService
     {
-        private const string VersionLabel = "General Release-v1.3.0";
+        private static string VersionLabel => PitmastersGrill.Services.AppReleaseMetadata.ReleaseLabel;
         private const int MaximumBundlesToRetain = 20;
 
         public static string GetDiagnosticsDirectory()

--- a/PitmastersGrill/PitmastersGrill.csproj
+++ b/PitmastersGrill/PitmastersGrill.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -8,10 +8,15 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
-    <Version>1.3.0</Version>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
-    <InformationalVersion>1.3.0</InformationalVersion>
+    <PmgReleaseVersion>1.3.0</PmgReleaseVersion>
+
+    <Version>$(PmgReleaseVersion)</Version>
+
+    <AssemblyVersion>$(PmgReleaseVersion).0</AssemblyVersion>
+
+    <FileVersion>$(PmgReleaseVersion).0</FileVersion>
+
+    <InformationalVersion>$(PmgReleaseVersion)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PitmastersGrill/Services/AppHttpDefaults.cs
+++ b/PitmastersGrill/Services/AppHttpDefaults.cs
@@ -2,6 +2,6 @@ namespace PitmastersGrill.Services
 {
     public static class AppHttpDefaults
     {
-        public const string GenericUserAgent = "PitmastersGrill/1.3.0";
+        public static string GenericUserAgent => AppReleaseMetadata.GenericUserAgent;
     }
 }

--- a/PitmastersGrill/Services/AppReleaseMetadata.cs
+++ b/PitmastersGrill/Services/AppReleaseMetadata.cs
@@ -1,0 +1,31 @@
+namespace PitmastersGrill.Services
+{
+    public static class AppReleaseMetadata
+    {
+        public const string ProductUserAgentName = "PitmastersGrill";
+        public const string DisplayName = "Pitmasters Grill";
+        public const string ReleaseStage = "General Release";
+
+        public static string VersionText => FormatVersion(typeof(AppReleaseMetadata).Assembly.GetName().Version);
+
+        public static string ReleaseLabel => $"{ReleaseStage}-v{VersionText}";
+
+        public static string GenericUserAgent => $"{ProductUserAgentName}/{VersionText}";
+
+        public static string PanelModeAlwaysEnabledText => $"Panel Mode is always enabled for PMG {VersionText}.";
+
+        private static string FormatVersion(System.Version? version)
+        {
+            if (version == null)
+            {
+                return "0.0.0";
+            }
+
+            var major = version.Major < 0 ? 0 : version.Major;
+            var minor = version.Minor < 0 ? 0 : version.Minor;
+            var build = version.Build < 0 ? 0 : version.Build;
+
+            return $"{major}.{minor}.{build}";
+        }
+    }
+}

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -11,6 +11,7 @@ This checklist does not replace judgment. It gives the release owner a consisten
 - [ ] Confirm the intended version number.
 - [ ] Confirm the app version in the project file.
 - [ ] Confirm README current-release references are correct.
+- [ ] Confirm `PmgReleaseVersion` in `PitmastersGrill/PitmastersGrill.csproj` is the intended release version.
 - [ ] Confirm patch notes exist for the release.
 - [ ] Confirm release notes accurately describe PMG's public-data boundaries.
 - [ ] Confirm update-awareness wording is accurate and does not imply auto-install behavior.


### PR DESCRIPTION
﻿## Summary
- Adds AppReleaseMetadata as the central app-visible release/version metadata helper.
- Replaces duplicated version labels in logging, diagnostics, Settings > Version, Panel Mode text, and HTTP defaults.
- Adds a single PmgReleaseVersion project property used by Version, AssemblyVersion, FileVersion, and InformationalVersion.
- Updates maintainer docs and release checklist guidance.

## Validation
- dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj
- dotnet build .\PitmastersGrill\PitmastersGrill.csproj
- Hard-coded v1.3.0 release string scan returned no output for the targeted app/version files.
- git --no-pager diff --check

## Issues
Closes #52
