### PR TITLE
Add automated PMG smoke regression script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ coverage/
 # Local publish profiles
 PitmastersGrill/Properties/PublishProfiles/
 .release/
+artifacts/smoke-tests/

--- a/PitmastersGrill/MainWindow.xaml
+++ b/PitmastersGrill/MainWindow.xaml
@@ -17,7 +17,7 @@
         PreviewKeyDown="Window_PreviewKeyDown"
         LocationChanged="Window_LocationChanged"
         SizeChanged="Window_SizeChanged"
-        StateChanged="Window_StateChanged">
+        StateChanged="Window_StateChanged" AutomationProperties.AutomationId="RootWindow">
 
     <Window.Resources>
         <local:ThreatCynoHullHighlightConverter x:Key="ThreatCynoHullHighlightConverter" />
@@ -454,7 +454,7 @@
                                 Panel.ZIndex="1"
                                 Background="#101418"
                                 IsItemsHost="True"
-                                KeyboardNavigation.TabIndex="1" />
+                                KeyboardNavigation.TabIndex="1"/>
 
                             <Border
                                 x:Name="ContentPanel"
@@ -469,7 +469,7 @@
                                     x:Name="PART_SelectedContentHost"
                                     Margin="0"
                                     ContentSource="SelectedContent"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                             </Border>
                         </Grid>
                     </ControlTemplate>
@@ -498,7 +498,7 @@
                                 ContentSource="Header"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
-                                RecognizesAccessKey="True" />
+                                RecognizesAccessKey="True"/>
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsSelected" Value="True">
@@ -576,7 +576,7 @@
                                    Height="32"
                                    Stretch="Uniform"
                                    SnapsToDevicePixels="True"
-                                   UseLayoutRounding="True"/>
+                                   UseLayoutRounding="True" AutomationProperties.AutomationId="HeaderLogoImage"/>
                         </Border>
                         <TextBlock Text="Pitmasters Grill"
                                    FontSize="20"
@@ -594,18 +594,18 @@
                                 Margin="0,0,6,0"
                                 ToolTip="Minimize PMG"
                                 Content="_"
-                                Click="MinimizeWindowButton_Click"/>
+                                Click="MinimizeWindowButton_Click" AutomationProperties.AutomationId="MinimizeWindowButton"/>
                         <Button x:Name="MaximizeRestoreWindowButton"
                                 Style="{StaticResource WindowControlButtonStyle}"
                                 Margin="0,0,6,0"
                                 ToolTip="Maximize PMG"
                                 Content="[]"
-                                Click="MaximizeRestoreWindowButton_Click"/>
+                                Click="MaximizeRestoreWindowButton_Click" AutomationProperties.AutomationId="MaximizeRestoreWindowButton"/>
                         <Button x:Name="CloseWindowButton"
                                 Style="{StaticResource WindowControlButtonStyle}"
                                 ToolTip="Close PMG"
                                 Content="X"
-                                Click="CloseWindowButton_Click"/>
+                                Click="CloseWindowButton_Click" AutomationProperties.AutomationId="CloseWindowButton"/>
                     </StackPanel>
 
                 </Grid>
@@ -686,14 +686,14 @@
             </Grid>
         </Border>
 
-        <Grid x:Name="MainContentGrid" Grid.Row="1" Margin="12">
+        <Grid x:Name="MainContentGrid" Grid.Row="1" Margin="12" AutomationProperties.AutomationId="MainContentGrid">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <Grid x:Name="TopCommandGrid" Grid.Row="0" Margin="0,0,0,6">
+            <Grid x:Name="TopCommandGrid" Grid.Row="0" Margin="0,0,0,6" AutomationProperties.AutomationId="TopCommandGrid">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
@@ -712,7 +712,7 @@
                         BorderThickness="1"
                         Cursor="SizeAll"
                         ToolTip="Drag to move PMG while Board Mode is enabled."
-                        MouseLeftButtonDown="CompactWindowDragHandle_MouseLeftButtonDown">
+                        MouseLeftButtonDown="CompactWindowDragHandle_MouseLeftButtonDown" AutomationProperties.AutomationId="CompactWindowDragHandle">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -736,7 +736,7 @@
                         Style="{StaticResource CommandStripButtonStyle}"
                         Margin="0,0,8,0"
                         Content="Clear"
-                        Click="ClearBoardButton_Click"/>
+                        Click="ClearBoardButton_Click" AutomationProperties.AutomationId="ClearBoardButton"/>
 
                 <TextBlock Grid.Column="1"
                            Margin="0,0,16,0"
@@ -751,14 +751,14 @@
                               Style="{StaticResource CompactModeToggleStyle}"
                               Margin="0,0,8,0"
                               Checked="CompactModeToggleButton_Changed"
-                              Unchecked="CompactModeToggleButton_Changed"/>
+                              Unchecked="CompactModeToggleButton_Changed" AutomationProperties.AutomationId="CompactModeToggleButton"/>
 
                 <Button Grid.Column="4"
                         x:Name="ExitApplicationButton"
                         Style="{StaticResource CommandStripButtonStyle}"
                         Content="Exit"
                         ToolTip="Exit PMG and stop PMG-owned background work."
-                        Click="ExitApplicationButton_Click"/>
+                        Click="ExitApplicationButton_Click" AutomationProperties.AutomationId="ExitApplicationButton"/>
             </Grid>
 
             <TabControl x:Name="MainTabControl"
@@ -766,7 +766,7 @@
                         Background="{DynamicResource WindowBackgroundBrush}"
                         BorderBrush="{DynamicResource PanelBorderBrush}"
                         SelectionChanged="MainTabControl_SelectionChanged"
-                        ItemContainerStyle="{StaticResource CompactAwareTabItemStyle}">
+                        ItemContainerStyle="{StaticResource CompactAwareTabItemStyle}" AutomationProperties.AutomationId="MainTabControl">
                 <TabItem Header="Analysis">
                     <ScrollViewer VerticalScrollBarVisibility="Auto"
                                   Padding="12"
@@ -786,29 +786,29 @@
                                                Margin="0,0,0,8"/>
                                     <TextBlock x:Name="AnalysisEmptyStateText"
                                                Style="{StaticResource SettingsLabelStyle}"
-                                               Text="No visible pilots yet. Load or refresh the Grill to see aggregate analysis."/>
+                                               Text="No visible pilots yet. Load or refresh the Grill to see aggregate analysis." AutomationProperties.AutomationId="AnalysisEmptyStateText"/>
                                     <StackPanel x:Name="AnalysisDetailsPanel"
-                                                Visibility="Collapsed">
+                                                Visibility="Collapsed" AutomationProperties.AutomationId="AnalysisDetailsPanel">
                                         <TextBlock x:Name="AnalysisVisibleCountsText"
                                                    Style="{StaticResource SettingsLabelStyle}"
-                                                   Text="Visible pilots: 0 | Watched pilots: 0"/>
+                                                   Text="Visible pilots: 0 | Watched pilots: 0" AutomationProperties.AutomationId="AnalysisVisibleCountsText"/>
                                         <TextBlock x:Name="AnalysisSignalsText"
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,2,0,0"
-                                                   Text="Confirmed cynos: Hard 0 | Covert 0 | Bait 0"/>
+                                                   Text="Confirmed cynos: Hard 0 | Covert 0 | Bait 0" AutomationProperties.AutomationId="AnalysisSignalsText"/>
                                         <TextBlock x:Name="AnalysisUniqueCountsText"
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,8,0,0"
-                                                   Text="Unique corps: 0 | Unique alliances: 0"/>
+                                                   Text="Unique corps: 0 | Unique alliances: 0" AutomationProperties.AutomationId="AnalysisUniqueCountsText"/>
                                         <TextBlock x:Name="AnalysisAllianceTopText"
                                                    Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,8,0,0"/>
+                                                   Margin="0,8,0,0" AutomationProperties.AutomationId="AnalysisAllianceTopText"/>
                                         <TextBlock x:Name="AnalysisCorpTopText"
                                                    Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,2,0,0"/>
+                                                   Margin="0,2,0,0" AutomationProperties.AutomationId="AnalysisCorpTopText"/>
                                         <TextBlock x:Name="AnalysisHighlightsText"
                                                    Style="{StaticResource SettingsLabelStyle}"
-                                                   Margin="0,8,0,0"/>
+                                                   Margin="0,8,0,0" AutomationProperties.AutomationId="AnalysisHighlightsText"/>
                                         <Grid Margin="0,10,0,0">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="*"/>
@@ -827,7 +827,7 @@
                                                          Foreground="{DynamicResource BodyTextBrush}"
                                                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                                                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                                         MouseDoubleClick="AnalysisAllianceListBox_MouseDoubleClick">
+                                                         MouseDoubleClick="AnalysisAllianceListBox_MouseDoubleClick" AutomationProperties.AutomationId="AnalysisAllianceListBox">
                                                     <ListBox.ItemTemplate>
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding DisplayText}"
@@ -850,7 +850,7 @@
                                                          Foreground="{DynamicResource BodyTextBrush}"
                                                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                                                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                                         MouseDoubleClick="AnalysisCorpListBox_MouseDoubleClick">
+                                                         MouseDoubleClick="AnalysisCorpListBox_MouseDoubleClick" AutomationProperties.AutomationId="AnalysisCorpListBox">
                                                     <ListBox.ItemTemplate>
                                                         <DataTemplate>
                                                             <TextBlock Text="{Binding DisplayText}"
@@ -898,7 +898,7 @@
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,0,0,0"
                                                    Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not detected"/>
+                                                   Text="Not detected" AutomationProperties.AutomationId="AnalysisCurrentCharacterText"/>
 
                                         <TextBlock Grid.Row="1"
                                                    Grid.Column="0"
@@ -910,7 +910,7 @@
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,0,0,0"
                                                    Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not detected"/>
+                                                   Text="Not detected" AutomationProperties.AutomationId="AnalysisCurrentSystemText"/>
 
                                         <TextBlock Grid.Row="2"
                                                    Grid.Column="0"
@@ -922,7 +922,7 @@
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,0,0,0"
                                                    Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not configured"/>
+                                                   Text="Not configured" AutomationProperties.AutomationId="AnalysisEvidenceSourceText"/>
 
                                         <TextBlock Grid.Row="3"
                                                    Grid.Column="0"
@@ -934,7 +934,7 @@
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,0,0,0"
                                                    Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Not detected"/>
+                                                   Text="Not detected" AutomationProperties.AutomationId="AnalysisObservedAtText"/>
 
                                         <TextBlock Grid.Row="4"
                                                    Grid.Column="0"
@@ -946,7 +946,7 @@
                                                    Style="{StaticResource SettingsLabelStyle}"
                                                    Margin="0,0,0,0"
                                                    Foreground="{DynamicResource BodyTextBrush}"
-                                                   Text="Unable to infer EVE context"/>
+                                                   Text="Unable to infer EVE context" AutomationProperties.AutomationId="AnalysisContextStatusText"/>
                                     </Grid>
                                     <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,8,0,0"
@@ -960,7 +960,7 @@
                 </TabItem>
                 <TabItem Header="Grill">
                     <Grid Background="{DynamicResource WindowBackgroundBrush}">
-                        <Grid x:Name="BoardOverlayHost">
+                        <Grid x:Name="BoardOverlayHost" AutomationProperties.AutomationId="BoardOverlayHost">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="60*"/>
                                 <ColumnDefinition Width="12*"/>
@@ -991,13 +991,13 @@
                                       PreviewMouseLeftButtonDown="PilotBoard_PreviewMouseLeftButtonDown"
                                       PreviewMouseLeftButtonUp="PilotBoard_PreviewMouseLeftButtonUp"
                                       PreviewMouseMove="PilotBoard_PreviewMouseMove"
-                                      SizeChanged="PilotBoard_SizeChanged" Grid.ColumnSpan="4">
+                                      SizeChanged="PilotBoard_SizeChanged" Grid.ColumnSpan="4" AutomationProperties.AutomationId="PilotBoard">
                                 <DataGrid.Resources>
                                     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Transparent"/>
                                     <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="Transparent"/>
                                 </DataGrid.Resources>
                                 <DataGrid.Columns>
-                                    <DataGridTemplateColumn x:Name="SigColumn" Header="Sig" Width="42" MinWidth="34">
+                                    <DataGridTemplateColumn x:Name="SigColumn" Header="Sig" Width="42" MinWidth="34" AutomationProperties.AutomationId="SigColumn">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <TextBlock HorizontalAlignment="Center"
@@ -1010,7 +1010,7 @@
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
 
-                                    <DataGridTemplateColumn x:Name="CharacterColumn" Header="Character" SortMemberPath="CharacterName" Width="120" MinWidth="72">
+                                    <DataGridTemplateColumn x:Name="CharacterColumn" Header="Character" SortMemberPath="CharacterName" Width="120" MinWidth="72" AutomationProperties.AutomationId="CharacterColumn">
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <DockPanel LastChildFill="True">
@@ -1021,12 +1021,12 @@
                                                                FontWeight="Bold"
                                                                Foreground="{DynamicResource WatchedPilotMarkerBrush}"
                                                                Text="★"
-                                                               Visibility="Collapsed"/>
+                                                               Visibility="Collapsed" AutomationProperties.AutomationId="WatchedPilotMarker"/>
                                                     <Button x:Name="PilotNoteButton"
                                                             DockPanel.Dock="Right"
                                                             Style="{StaticResource PilotNoteButtonStyle}"
                                                             Content="✎"
-                                                            Click="PilotNoteButton_Click"/>
+                                                            Click="PilotNoteButton_Click" AutomationProperties.AutomationId="PilotNoteButton"/>
                                                     <TextBlock Text="{Binding CharacterName}"
                                                                VerticalAlignment="Center"
                                                                ToolTip="{Binding BoardHoverToolTip}"
@@ -1045,17 +1045,17 @@
                                             </DataTemplate>
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
-                                    <DataGridTextColumn x:Name="AllianceColumn" Header="Alliance" Binding="{Binding AllianceNameDisplay}" Width="120" MinWidth="72"/>
-                                    <DataGridTextColumn x:Name="CorpColumn" Header="Corp" Binding="{Binding CorpNameDisplay}" Width="140" MinWidth="82"/>
-                                    <DataGridTextColumn x:Name="KillsColumn" Header="Kills" Binding="{Binding KillCount}" Width="55" MinWidth="42"/>
-                                    <DataGridTextColumn x:Name="LossesColumn" Header="Losses" Binding="{Binding LossCount}" Width="55" MinWidth="42"/>
+                                    <DataGridTextColumn x:Name="AllianceColumn" Header="Alliance" Binding="{Binding AllianceNameDisplay}" Width="120" MinWidth="72" AutomationProperties.AutomationId="AllianceColumn"/>
+                                    <DataGridTextColumn x:Name="CorpColumn" Header="Corp" Binding="{Binding CorpNameDisplay}" Width="140" MinWidth="82" AutomationProperties.AutomationId="CorpColumn"/>
+                                    <DataGridTextColumn x:Name="KillsColumn" Header="Kills" Binding="{Binding KillCount}" Width="55" MinWidth="42" AutomationProperties.AutomationId="KillsColumn"/>
+                                    <DataGridTextColumn x:Name="LossesColumn" Header="Losses" Binding="{Binding LossCount}" Width="55" MinWidth="42" AutomationProperties.AutomationId="LossesColumn"/>
                                     <DataGridTextColumn x:Name="AvgFleetSizeColumn"
                                                         Header="Avg Fleet Size"
                                                         Binding="{Binding AvgAttackersWhenAttacking, StringFormat={}{0:0}}"
-                                                        Width="70" MinWidth="48"/>
-                                    <DataGridTextColumn x:Name="LastShipSeenColumn" Header="Last Ship Seen" Binding="{Binding LastShipSeenName}" Width="100" MinWidth="64"/>
-                                    <DataGridTextColumn x:Name="LastSeenColumn" Header="Last Seen" Binding="{Binding LastShipSeenDateDisplay}" SortMemberPath="LastShipSeenAtUtc" Width="90" MinWidth="54"/>
-                                    <DataGridTextColumn x:Name="CynoHullSeenColumn" Header="Cyno Hull Seen" Binding="{Binding LastPublicCynoCapableHull}" Width="110" MinWidth="70"/>
+                                                        Width="70" MinWidth="48" AutomationProperties.AutomationId="AvgFleetSizeColumn"/>
+                                    <DataGridTextColumn x:Name="LastShipSeenColumn" Header="Last Ship Seen" Binding="{Binding LastShipSeenName}" Width="100" MinWidth="64" AutomationProperties.AutomationId="LastShipSeenColumn"/>
+                                    <DataGridTextColumn x:Name="LastSeenColumn" Header="Last Seen" Binding="{Binding LastShipSeenDateDisplay}" SortMemberPath="LastShipSeenAtUtc" Width="90" MinWidth="54" AutomationProperties.AutomationId="LastSeenColumn"/>
+                                    <DataGridTextColumn x:Name="CynoHullSeenColumn" Header="Cyno Hull Seen" Binding="{Binding LastPublicCynoCapableHull}" Width="110" MinWidth="70" AutomationProperties.AutomationId="CynoHullSeenColumn"/>
                                 </DataGrid.Columns>
                             </DataGrid>
 
@@ -1071,7 +1071,7 @@
                                     BorderThickness="1"
                                     CornerRadius="4"
                                     Panel.ZIndex="20"
-                                    Grid.ColumnSpan="4">
+                                    Grid.ColumnSpan="4" AutomationProperties.AutomationId="BoardModeHintOverlay">
                                 <TextBlock Text="Board Mode enabled. Press Insert to return to normal mode."
                                            Foreground="{DynamicResource HeaderTextBrush}"
                                            FontWeight="SemiBold"/>
@@ -1089,7 +1089,7 @@
                                     BorderBrush="{DynamicResource PanelBorderBrush}"
                                     BorderThickness="1"
                                     CornerRadius="4"
-                                    Panel.ZIndex="10" Grid.Column="3">
+                                    Panel.ZIndex="10" Grid.Column="3" AutomationProperties.AutomationId="DetailPane">
                                 <Grid>
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto"/>
@@ -1120,14 +1120,14 @@
                                                Foreground="{DynamicResource HeaderTextBrush}"
                                                TextWrapping="Wrap"
                                                TextTrimming="None"
-                                               Margin="0,0,12,0"/>
+                                               Margin="0,0,12,0" AutomationProperties.AutomationId="SelectedCharacterText"/>
 
                                     <Button Grid.Row="0"
                                             Grid.Column="1"
                                             x:Name="CloseDetailsButton"
                                             Padding="12,4"
                                             Content="Close Details"
-                                            Click="CloseDetailsButton_Click"/>
+                                            Click="CloseDetailsButton_Click" AutomationProperties.AutomationId="CloseDetailsButton"/>
 
                                     <TextBlock Grid.Row="1"
                                                Grid.ColumnSpan="2"
@@ -1135,7 +1135,7 @@
                                                Margin="0,12,0,0"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Full Corp: --"/>
+                                               Text="Full Corp: --" AutomationProperties.AutomationId="FullCorpText"/>
 
                                     <TextBlock Grid.Row="2"
                                                Grid.ColumnSpan="2"
@@ -1143,7 +1143,7 @@
                                                Margin="0,8,0,0"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Full Alliance: --"/>
+                                               Text="Full Alliance: --" AutomationProperties.AutomationId="FullAllianceText"/>
 
                                     <TextBlock Grid.Row="3"
                                                Grid.ColumnSpan="2"
@@ -1151,7 +1151,7 @@
                                                Margin="0,8,0,0"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Freshness: --"/>
+                                               Text="Freshness: --" AutomationProperties.AutomationId="FreshnessText"/>
 
                                     <TextBlock Grid.Row="4"
                                                Grid.ColumnSpan="2"
@@ -1159,7 +1159,7 @@
                                                Margin="0,8,0,0"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Recent Public Kill/Loss Activity: --"/>
+                                               Text="Recent Public Kill/Loss Activity: --" AutomationProperties.AutomationId="RecentPublicActivityText"/>
 
                                     <TextBlock Grid.Row="5"
                                                Grid.ColumnSpan="2"
@@ -1168,7 +1168,7 @@
                                                FontWeight="SemiBold"
                                                Foreground="{DynamicResource AccentEmberBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Cyno Signal: Unknown"/>
+                                               Text="Cyno Signal: Unknown" AutomationProperties.AutomationId="CynoSignalText"/>
 
                                     <ProgressBar Grid.Row="6"
                                                  Grid.ColumnSpan="2"
@@ -1179,7 +1179,7 @@
                                                  Value="0"
                                                  Foreground="{DynamicResource AccentEmberBrush}"
                                                  Background="{DynamicResource SurfaceBrush}"
-                                                 Margin="0,0,0,6"/>
+                                                 Margin="0,0,0,6" AutomationProperties.AutomationId="CynoConfidenceBar"/>
 
                                     <TextBlock Grid.Row="7"
                                                Grid.ColumnSpan="2"
@@ -1187,7 +1187,7 @@
                                                Margin="0,0,0,4"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Evidence: --"/>
+                                               Text="Evidence: --" AutomationProperties.AutomationId="CynoEvidenceText"/>
 
                                     <TextBlock Grid.Row="8"
                                                Grid.ColumnSpan="2"
@@ -1195,7 +1195,7 @@
                                                Margin="0,0,0,4"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Limitations: --"/>
+                                               Text="Limitations: --" AutomationProperties.AutomationId="CynoLimitationsText"/>
 
                                     <TextBlock Grid.Row="9"
                                                Grid.ColumnSpan="2"
@@ -1203,7 +1203,7 @@
                                                Margin="0,8,0,0"
                                                Foreground="{DynamicResource MutedTextBrush}"
                                                TextWrapping="Wrap"
-                                               Text="Sources / Freshness: --"/>
+                                               Text="Sources / Freshness: --" AutomationProperties.AutomationId="ExplainabilityText"/>
 
                                     <Grid Grid.Row="10"
                                           Grid.ColumnSpan="2"
@@ -1224,20 +1224,20 @@
                                                     Style="{StaticResource DetailActionLinkButtonStyle}"
                                                     Foreground="{DynamicResource SuccessGreenBrush}"
                                                     Content="Watch"
-                                                    Click="WatchPilotDetailAction_Click"/>
+                                                    Click="WatchPilotDetailAction_Click" AutomationProperties.AutomationId="WatchPilotDetailAction"/>
                                             <CheckBox x:Name="BaitOverrideCheckBox"
                                                       VerticalAlignment="Center"
                                                       Foreground="{DynamicResource BodyTextBrush}"
                                                       Content="Bait"
                                                       Margin="0,0,10,0"
                                                       Checked="BaitOverrideCheckBox_Changed"
-                                                      Unchecked="BaitOverrideCheckBox_Changed"/>
+                                                      Unchecked="BaitOverrideCheckBox_Changed" AutomationProperties.AutomationId="BaitOverrideCheckBox"/>
                                             <CheckBox x:Name="KnownCynoOverrideCheckBox"
                                                       VerticalAlignment="Center"
                                                       Foreground="{DynamicResource BodyTextBrush}"
                                                       Content="Known-Cyno Override"
                                                       Checked="KnownCynoOverrideCheckBox_Changed"
-                                                      Unchecked="KnownCynoOverrideCheckBox_Changed"/>
+                                                      Unchecked="KnownCynoOverrideCheckBox_Changed" AutomationProperties.AutomationId="KnownCynoOverrideCheckBox"/>
                                         </StackPanel>
                                     </Grid>
 
@@ -1254,7 +1254,7 @@
                                                  AcceptsReturn="True"
                                                  TextWrapping="Wrap"
                                                  VerticalScrollBarVisibility="Auto"
-                                                 MinHeight="100"/>
+                                                 MinHeight="100" AutomationProperties.AutomationId="NotesTagsBox"/>
 
                                         <StackPanel Grid.Row="1"
                                                     Orientation="Horizontal"
@@ -1263,12 +1263,12 @@
                                                     Padding="12,6"
                                                     Margin="0,0,8,0"
                                                     Content="Ignore Alliance"
-                                                    Click="IgnoreAllianceButton_Click"/>
+                                                    Click="IgnoreAllianceButton_Click" AutomationProperties.AutomationId="IgnoreAllianceButton"/>
 
                                             <Button x:Name="OpenZkillButton"
                                                     Padding="12,6"
                                                     Content="Open zKill"
-                                                    Click="OpenZkillButton_Click"/>
+                                                    Click="OpenZkillButton_Click" AutomationProperties.AutomationId="OpenZkillButton"/>
                                         </StackPanel>
                                     </Grid>
                                 </Grid>
@@ -1278,10 +1278,10 @@
                 </TabItem>
 
                 <TabItem Header="Intel">
-                    <views:IntelSupportView x:Name="IntelSupportViewControl"/>
+                    <views:IntelSupportView x:Name="IntelSupportViewControl" AutomationProperties.AutomationId="IntelSupportViewControl"/>
                 </TabItem>
                 <TabItem Header="Ignore List">
-                    <views:IgnoreAllianceListView x:Name="IgnoreAllianceListViewControl"/>
+                    <views:IgnoreAllianceListView x:Name="IgnoreAllianceListViewControl" AutomationProperties.AutomationId="IgnoreAllianceListViewControl"/>
                 </TabItem>
 
                 <TabItem Header="Settings">
@@ -1308,7 +1308,7 @@
                                                       Foreground="{DynamicResource BodyTextBrush}"
                                                       Margin="0,0,0,10"
                                                       Checked="DarkModeCheckBox_Changed"
-                                                      Unchecked="DarkModeCheckBox_Changed"/>
+                                                      Unchecked="DarkModeCheckBox_Changed" AutomationProperties.AutomationId="DarkModeCheckBox"/>
 
                                             <TextBlock Text="PMG Theme"
                                                        Foreground="{DynamicResource BodyTextBrush}"
@@ -1318,7 +1318,7 @@
                                                       Width="220"
                                                       HorizontalAlignment="Left"
                                                       Margin="0,0,0,10"
-                                                      SelectionChanged="VisualThemeComboBox_SelectionChanged">
+                                                      SelectionChanged="VisualThemeComboBox_SelectionChanged" AutomationProperties.AutomationId="VisualThemeComboBox">
                                                 <ComboBoxItem Content="Charcoal Ops"/>
                                                 <ComboBoxItem Content="Tactical Grill"/>
                                                 <ComboBoxItem Content="Classic PMG Grill"/>
@@ -1334,7 +1334,7 @@
                                                       Foreground="{DynamicResource BodyTextBrush}"
                                                       Margin="0,0,0,10"
                                                       Checked="AlwaysOnTopCheckBox_Changed"
-                                                      Unchecked="AlwaysOnTopCheckBox_Changed"/>
+                                                      Unchecked="AlwaysOnTopCheckBox_Changed" AutomationProperties.AutomationId="AlwaysOnTopCheckBox"/>
 
                                             <CheckBox x:Name="PanelModeCheckBox"
                                                       Content="Enable Panel Mode on next launch"
@@ -1342,14 +1342,14 @@
                                                       Margin="0,0,0,6"
                                                       Visibility="Collapsed"
                                                       Checked="PanelModeCheckBox_Changed"
-                                                      Unchecked="PanelModeCheckBox_Changed"/>
+                                                      Unchecked="PanelModeCheckBox_Changed" AutomationProperties.AutomationId="PanelModeCheckBox"/>
 
                                             <TextBlock x:Name="PanelModeRestartNoticeText"
                                                        Foreground="{DynamicResource MutedTextBrush}"
                                                        FontSize="12"
                                                        Margin="24,0,0,14"
                                                        Visibility="Collapsed"
-                                                       Text="{x:Static services:AppReleaseMetadata.PanelModeAlwaysEnabledText}"/>
+                                                       Text="{x:Static services:AppReleaseMetadata.PanelModeAlwaysEnabledText}" AutomationProperties.AutomationId="PanelModeRestartNoticeText"/>
 
                                             <TextBlock Text="Window Surface Opacity"
                                                        Foreground="{DynamicResource BodyTextBrush}"
@@ -1367,14 +1367,14 @@
                                                         Maximum="100"
                                                         TickFrequency="5"
                                                         IsSnapToTickEnabled="False"
-                                                        ValueChanged="WindowOpacitySlider_ValueChanged"/>
+                                                        ValueChanged="WindowOpacitySlider_ValueChanged" AutomationProperties.AutomationId="WindowOpacitySlider"/>
 
                                                 <TextBlock Grid.Column="1"
                                                            x:Name="WindowOpacityValueText"
                                                            Margin="12,0,0,0"
                                                            VerticalAlignment="Center"
                                                            Foreground="{DynamicResource BodyTextBrush}"
-                                                           Text="100%"/>
+                                                           Text="100%" AutomationProperties.AutomationId="WindowOpacityValueText"/>
                                             </Grid>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
@@ -1387,7 +1387,7 @@
                                                         Padding="14,6"
                                                         Margin="0,0,10,0"
                                                         Content="Reset Window Layout"
-                                                        Click="ResetWindowLayoutButton_Click"/>
+                                                        Click="ResetWindowLayoutButton_Click" AutomationProperties.AutomationId="ResetWindowLayoutButton"/>
                                             </WrapPanel>
                                         </StackPanel>
                                     </Border>
@@ -1416,7 +1416,7 @@
                                                       Width="260"
                                                       HorizontalAlignment="Left"
                                                       Margin="0,0,0,10"
-                                                      SelectionChanged="ColorBlindModeComboBox_SelectionChanged">
+                                                      SelectionChanged="ColorBlindModeComboBox_SelectionChanged" AutomationProperties.AutomationId="ColorBlindModeComboBox">
                                                 <ComboBoxItem Content="Off / Standard"/>
                                                 <ComboBoxItem Content="Deuteranopia-friendly"/>
                                                 <ComboBoxItem Content="Protanopia-friendly"/>
@@ -1453,7 +1453,7 @@
                                                       Foreground="{DynamicResource BodyTextBrush}"
                                                       Margin="0,8,0,8"
                                                       Checked="ShowBoardGridLinesCheckBox_Changed"
-                                                      Unchecked="ShowBoardGridLinesCheckBox_Changed"/>
+                                                      Unchecked="ShowBoardGridLinesCheckBox_Changed" AutomationProperties.AutomationId="ShowBoardGridLinesCheckBox"/>
 
                                             <TextBlock Text="Grill board text size"
                                                        Foreground="{DynamicResource BodyTextBrush}"
@@ -1463,7 +1463,7 @@
                                                       Width="120"
                                                       HorizontalAlignment="Left"
                                                       Margin="0,0,0,10"
-                                                      SelectionChanged="BoardTextSizeComboBox_SelectionChanged">
+                                                      SelectionChanged="BoardTextSizeComboBox_SelectionChanged" AutomationProperties.AutomationId="BoardTextSizeComboBox">
                                                 <ComboBoxItem Content="10"/>
                                                 <ComboBoxItem Content="11"/>
                                                 <ComboBoxItem Content="12"/>
@@ -1481,7 +1481,7 @@
                                                       Width="180"
                                                       HorizontalAlignment="Left"
                                                       Margin="0,0,0,12"
-                                                      SelectionChanged="BoardFontFamilyComboBox_SelectionChanged">
+                                                      SelectionChanged="BoardFontFamilyComboBox_SelectionChanged" AutomationProperties.AutomationId="BoardFontFamilyComboBox">
                                                 <ComboBoxItem Content="App Default"/>
                                                 <ComboBoxItem Content="Segoe UI"/>
                                                 <ComboBoxItem Content="Consolas"/>
@@ -1506,7 +1506,7 @@
                                                       Foreground="{DynamicResource BodyTextBrush}"
                                                       Margin="0,8,0,4"
                                                       Checked="ShowCorpAllianceCountsCheckBox_Changed"
-                                                      Unchecked="ShowCorpAllianceCountsCheckBox_Changed"/>
+                                                      Unchecked="ShowCorpAllianceCountsCheckBox_Changed" AutomationProperties.AutomationId="ShowCorpAllianceCountsCheckBox"/>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                                        Margin="24,0,0,8"
@@ -1518,63 +1518,63 @@
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowSigColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowAllianceColumnCheckBox"
                                                           Content="Alliance"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowAllianceColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowCorpColumnCheckBox"
                                                           Content="Corp"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowCorpColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowKillsColumnCheckBox"
                                                           Content="Kills"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowKillsColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowLossesColumnCheckBox"
                                                           Content="Losses"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowLossesColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowAvgFleetSizeColumnCheckBox"
                                                           Content="Avg Fleet Size"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowAvgFleetSizeColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowLastShipSeenColumnCheckBox"
                                                           Content="Last Ship Seen"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowLastShipSeenColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowLastSeenColumnCheckBox"
                                                           Content="Last Seen"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowLastSeenColumnCheckBox"/>
 
                                                 <CheckBox x:Name="ShowCynoHullSeenColumnCheckBox"
                                                           Content="Cyno Hull Seen"
                                                           Foreground="{DynamicResource BodyTextBrush}"
                                                           Margin="0,0,18,8"
                                                           Checked="BoardColumnVisibilityCheckBox_Changed"
-                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed"/>
+                                                          Unchecked="BoardColumnVisibilityCheckBox_Changed" AutomationProperties.AutomationId="ShowCynoHullSeenColumnCheckBox"/>
                                             </WrapPanel>
 
                                             <WrapPanel>
@@ -1583,21 +1583,21 @@
                                                         Padding="14,6"
                                                         Margin="0,0,10,0"
                                                         Content="Show All"
-                                                        Click="ShowAllBoardColumnsButton_Click"/>
+                                                        Click="ShowAllBoardColumnsButton_Click" AutomationProperties.AutomationId="ShowAllBoardColumnsButton"/>
 
                                                 <Button x:Name="ResetBoardColumnsButton"
                                                         Width="140"
                                                         Padding="14,6"
                                                         Margin="0,0,10,0"
                                                         Content="Reset Visibility Defaults"
-                                                        Click="ResetBoardColumnsButton_Click"/>
+                                                        Click="ResetBoardColumnsButton_Click" AutomationProperties.AutomationId="ResetBoardColumnsButton"/>
 
                                                 <Button x:Name="ResetBoardLayoutButton"
                                                         Width="140"
                                                         Padding="14,6"
                                                         Margin="0,0,10,0"
                                                         Content="Reset Layout"
-                                                        Click="ResetBoardLayoutButton_Click"/>
+                                                        Click="ResetBoardLayoutButton_Click" AutomationProperties.AutomationId="ResetBoardLayoutButton"/>
                                             </WrapPanel>
 
                                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
@@ -1649,11 +1649,11 @@
                                     Content="Check for Updates"
                                     Width="150"
                                     HorizontalAlignment="Left"
-                                    Click="ManualUpdateCheckButton_Click" />
+                                    Click="ManualUpdateCheckButton_Click"  AutomationProperties.AutomationId="ManualUpdateCheckButton"/>
                             <TextBlock x:Name="ManualUpdateStatusText"
                                        Text="Manual update check has not run this session."
                                        TextWrapping="Wrap"
-                                       Margin="0,8,0,0" />
+                                       Margin="0,8,0,0"  AutomationProperties.AutomationId="ManualUpdateStatusText"/>
                         </StackPanel>
                                         </StackPanel>
                                     </Border>
@@ -1661,7 +1661,7 @@
                             </TabItem>
 
                             <TabItem Header="Diagnostics" Style="{StaticResource PmgNestedSubTabItemStyle}" Background="#1E252C" Foreground="#F2EFE6">
-                                <views:DiagnosticsSupportView x:Name="DiagnosticsSupportViewControl"/>
+                                <views:DiagnosticsSupportView x:Name="DiagnosticsSupportViewControl" AutomationProperties.AutomationId="DiagnosticsSupportViewControl"/>
                             </TabItem>
 
                         </TabControl>
@@ -1697,7 +1697,7 @@
                                             ContentSource="Header"
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
-                                            RecognizesAccessKey="True" />
+                                            RecognizesAccessKey="True"/>
                                     </Border>
                                     <ControlTemplate.Triggers>
                                         <Trigger Property="IsSelected" Value="True">
@@ -1916,7 +1916,7 @@
                     Padding="8,5"
                     Background="{DynamicResource SurfaceAltBrush}"
                     BorderBrush="{DynamicResource PanelBorderBrush}"
-                    BorderThickness="1">
+                    BorderThickness="1" AutomationProperties.AutomationId="BoardStatusFooter">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -1935,7 +1935,7 @@
                                TextWrapping="NoWrap"
                                TextTrimming="CharacterEllipsis"
                                VerticalAlignment="Center"
-                               Margin="0,0,12,0"/>
+                               Margin="0,0,12,0" AutomationProperties.AutomationId="BoardPopulationStatusText"/>
 
                     <TextBlock x:Name="LastRefreshedText"
                                Grid.Row="0"
@@ -1944,7 +1944,7 @@
                                Text="Last Refreshed: --"
                                TextWrapping="NoWrap"
                                TextTrimming="CharacterEllipsis"
-                               VerticalAlignment="Center"/>
+                               VerticalAlignment="Center" AutomationProperties.AutomationId="LastRefreshedText"/>
 
                     <TextBlock x:Name="BoardSummaryText"
                                Grid.Row="1"
@@ -1955,7 +1955,7 @@
                                Margin="0,5,0,0"
                                TextWrapping="Wrap"
                                TextTrimming="CharacterEllipsis"
-                               VerticalAlignment="Center"/>
+                               VerticalAlignment="Center" AutomationProperties.AutomationId="BoardSummaryText"/>
                 </Grid>
             </Border>
         </Grid>

--- a/PitmastersGrill/Views/DiagnosticsSupportView.xaml
+++ b/PitmastersGrill/Views/DiagnosticsSupportView.xaml
@@ -34,7 +34,7 @@
                             HorizontalAlignment="Left"
                             Margin="0,0,10,8"
                             Content="Logs"
-                            Click="OpenLogsButton_Click"/>
+                            Click="OpenLogsButton_Click" AutomationProperties.AutomationId="OpenLogsButton"/>
 
                     <Button x:Name="PackageDiagnosticsButton"
                             Width="160"
@@ -42,7 +42,7 @@
                             HorizontalAlignment="Left"
                             Margin="0,0,10,8"
                             Content="Export Diagnostics Package"
-                            Click="PackageDiagnosticsButton_Click"/>
+                            Click="PackageDiagnosticsButton_Click" AutomationProperties.AutomationId="PackageDiagnosticsButton"/>
 
                     <Button x:Name="OpenDiagnosticsFolderButton"
                             Width="160"
@@ -50,7 +50,7 @@
                             HorizontalAlignment="Left"
                             Margin="0,0,10,8"
                             Content="Diagnostics Folder"
-                            Click="OpenDiagnosticsFolderButton_Click"/>
+                            Click="OpenDiagnosticsFolderButton_Click" AutomationProperties.AutomationId="OpenDiagnosticsFolderButton"/>
 
                     <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                VerticalAlignment="Center"
@@ -61,7 +61,7 @@
                               Width="140"
                               VerticalAlignment="Center"
                               Margin="0,0,0,8"
-                              SelectionChanged="LogLevelComboBox_SelectionChanged">
+                              SelectionChanged="LogLevelComboBox_SelectionChanged" AutomationProperties.AutomationId="LogLevelComboBox">
                         <ComboBoxItem Content="Normal"/>
                         <ComboBoxItem Content="Debug"/>
                     </ComboBox>
@@ -70,7 +70,7 @@
                 <TextBlock x:Name="DiagnosticsStatusText"
                            Style="{StaticResource SettingsLabelStyle}"
                            Margin="0,6,0,0"
-                           Text="Diagnostics ready."/>
+                           Text="Diagnostics ready." AutomationProperties.AutomationId="DiagnosticsStatusText"/>
 
                 <TextBlock Text="Provider Health"
                            FontSize="16"
@@ -84,14 +84,14 @@
                             Padding="14,6"
                             Margin="0,0,10,0"
                             Content="Refresh Providers"
-                            Click="RefreshProviderHealthButton_Click"/>
+                            Click="RefreshProviderHealthButton_Click" AutomationProperties.AutomationId="RefreshProviderHealthButton"/>
                 </WrapPanel>
 
                 <DataGrid x:Name="ProviderHealthGrid"
                           AutoGenerateColumns="False"
                           IsReadOnly="True"
                           Height="150"
-                          Margin="0,0,0,12">
+                          Margin="0,0,0,12" AutomationProperties.AutomationId="ProviderHealthGrid">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Provider" Binding="{Binding ProviderName}" Width="1.4*"/>
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="0.9*"/>
@@ -116,38 +116,38 @@
                             Padding="14,6"
                             Margin="0,0,10,8"
                             Content="Refresh Cache Stats"
-                            Click="RefreshCacheStatsButton_Click"/>
+                            Click="RefreshCacheStatsButton_Click" AutomationProperties.AutomationId="RefreshCacheStatsButton"/>
                     <Button x:Name="ClearExpiredCacheButton"
                             Width="150"
                             Padding="14,6"
                             Margin="0,0,10,8"
                             Content="Clear Expired"
-                            Click="ClearExpiredCacheButton_Click"/>
+                            Click="ClearExpiredCacheButton_Click" AutomationProperties.AutomationId="ClearExpiredCacheButton"/>
                     <Button x:Name="VacuumCacheButton"
                             Width="150"
                             Padding="14,6"
                             Margin="0,0,10,8"
                             Content="Compact / Vacuum"
-                            Click="VacuumCacheButton_Click"/>
+                            Click="VacuumCacheButton_Click" AutomationProperties.AutomationId="VacuumCacheButton"/>
                     <Button x:Name="ClearAllCacheButton"
                             Width="150"
                             Padding="14,6"
                             Margin="0,0,10,8"
                             Content="Clear All Cache"
-                            Click="ClearAllCacheButton_Click"/>
+                            Click="ClearAllCacheButton_Click" AutomationProperties.AutomationId="ClearAllCacheButton"/>
                     <Button x:Name="RebuildKillmailDerivedIntelButton"
                             Width="210"
                             Padding="14,6"
                             Margin="0,0,10,8"
                             Content="Rebuild Killmail Derived Intel"
-                            Click="RebuildKillmailDerivedIntelButton_Click"/>
+                            Click="RebuildKillmailDerivedIntelButton_Click" AutomationProperties.AutomationId="RebuildKillmailDerivedIntelButton"/>
                 </WrapPanel>
 
                 <TextBlock x:Name="CacheStatsText"
                            Style="{StaticResource SettingsLabelStyle}"
                            FontFamily="Consolas"
                            TextWrapping="Wrap"
-                           Text="Cache stats not loaded."/>
+                           Text="Cache stats not loaded." AutomationProperties.AutomationId="CacheStatsText"/>
 
                 <TextBlock Style="{StaticResource SettingsLabelStyle}"
                            Margin="0,10,0,0"

--- a/PitmastersGrill/Views/IgnoreAllianceListView.xaml
+++ b/PitmastersGrill/Views/IgnoreAllianceListView.xaml
@@ -51,13 +51,13 @@
                              Background="{DynamicResource SurfaceBrush}"
                              Foreground="{DynamicResource BodyTextBrush}"
                              BorderBrush="{DynamicResource PanelBorderBrush}"
-                             Margin="0,0,0,10"/>
+                             Margin="0,0,0,10" AutomationProperties.AutomationId="IgnoreIdsInputTextBox"/>
 
                     <WrapPanel>
                         <ComboBox x:Name="IgnoreTypeComboBox"
                                   Width="150"
                                   Height="32"
-                                  Margin="0,0,8,8">
+                                  Margin="0,0,8,8" AutomationProperties.AutomationId="IgnoreTypeComboBox">
                             <ComboBoxItem Content="Pilot"/>
                             <ComboBoxItem Content="Corporation"/>
                             <ComboBoxItem Content="Alliance"/>
@@ -68,35 +68,35 @@
                                 Width="92"
                                 Height="32"
                                 Margin="0,0,8,8"
-                                Click="AddIgnoreIdsButton_Click"/>
+                                Click="AddIgnoreIdsButton_Click" AutomationProperties.AutomationId="AddIgnoreIdsButton"/>
 
                         <Button x:Name="SaveIgnoreListButton"
                                 Content="Save List"
                                 Width="92"
                                 Height="32"
                                 Margin="0,0,8,8"
-                                Click="SaveIgnoreListButton_Click"/>
+                                Click="SaveIgnoreListButton_Click" AutomationProperties.AutomationId="SaveIgnoreListButton"/>
 
                         <Button x:Name="RemoveSelectedIgnoreButton"
                                 Content="Remove Selected"
                                 Width="124"
                                 Height="32"
                                 Margin="0,0,8,8"
-                                Click="RemoveSelectedIgnoreButton_Click"/>
+                                Click="RemoveSelectedIgnoreButton_Click" AutomationProperties.AutomationId="RemoveSelectedIgnoreButton"/>
 
                         <Button x:Name="ClearIgnoreListButton"
                                 Content="Clear All"
                                 Width="92"
                                 Height="32"
                                 Margin="0,0,8,8"
-                                Click="ClearIgnoreListButton_Click"/>
+                                Click="ClearIgnoreListButton_Click" AutomationProperties.AutomationId="ClearIgnoreListButton"/>
 
                         <Button x:Name="RefreshNamesButton"
                                 Content="Refresh Names"
                                 Width="116"
                                 Height="32"
                                 Margin="0,0,8,8"
-                                Click="RefreshNamesButton_Click"/>
+                                Click="RefreshNamesButton_Click" AutomationProperties.AutomationId="RefreshNamesButton"/>
                     </WrapPanel>
                 </StackPanel>
             </Border>
@@ -122,7 +122,7 @@
                               SelectionMode="Extended"
                               Background="{DynamicResource SurfaceBrush}"
                               Foreground="{DynamicResource BodyTextBrush}"
-                              BorderBrush="{DynamicResource PanelBorderBrush}">
+                              BorderBrush="{DynamicResource PanelBorderBrush}" AutomationProperties.AutomationId="IgnoredEntriesGrid">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="1*"/>
                             <DataGridTextColumn Header="Name" Binding="{Binding DisplayName}" Width="2*"/>
@@ -134,7 +134,7 @@
 
             <TextBlock x:Name="IgnoreListStatusText"
                        Margin="12,0,12,12"
-                       Foreground="{DynamicResource MutedTextBrush}"/>
+                       Foreground="{DynamicResource MutedTextBrush}" AutomationProperties.AutomationId="IgnoreListStatusText"/>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/PitmastersGrill/Views/IntelSupportView.xaml
+++ b/PitmastersGrill/Views/IntelSupportView.xaml
@@ -32,17 +32,17 @@
                             Padding="12,8"
                             BorderBrush="{DynamicResource PanelBorderBrush}"
                             BorderThickness="1"
-                            Margin="0,0,0,12">
+                            Margin="0,0,0,12" AutomationProperties.AutomationId="IntelUpdateBanner">
                         <StackPanel>
                             <TextBlock x:Name="IntelUpdateStatusText"
                                        Foreground="White"
                                        FontWeight="SemiBold"
                                        FontSize="16"
-                                       Text="Intel current"/>
+                                       Text="Intel current" AutomationProperties.AutomationId="IntelUpdateStatusText"/>
                             <TextBlock x:Name="IntelUpdateDetailText"
                                        Foreground="#F3F3F3"
                                        FontSize="12"
-                                       Text="Through latest archive"/>
+                                       Text="Through latest archive" AutomationProperties.AutomationId="IntelUpdateDetailText"/>
                         </StackPanel>
                     </Border>
 
@@ -60,7 +60,7 @@
                                     <TextBlock x:Name="IntelLastUpdatedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No successful local intel update recorded yet."/>
+                                               Text="No successful local intel update recorded yet." AutomationProperties.AutomationId="IntelLastUpdatedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -70,7 +70,7 @@
                                     <TextBlock x:Name="IntelCurrentUpdateStatusText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No update currently running."/>
+                                               Text="No update currently running." AutomationProperties.AutomationId="IntelCurrentUpdateStatusText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -80,7 +80,7 @@
                                     <TextBlock x:Name="IntelOldestKillmailDayText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No local killmail days recorded yet."/>
+                                               Text="No local killmail days recorded yet." AutomationProperties.AutomationId="IntelOldestKillmailDayText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -90,7 +90,7 @@
                                     <TextBlock x:Name="IntelNewestKillmailDayText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No local killmail days recorded yet."/>
+                                               Text="No local killmail days recorded yet." AutomationProperties.AutomationId="IntelNewestKillmailDayText"/>
                                 </StackPanel>
                             </UniformGrid>
 
@@ -102,11 +102,11 @@
                                          Margin="0,6,0,4"
                                          Minimum="0"
                                          Maximum="100"
-                                         Value="0"/>
+                                         Value="0" AutomationProperties.AutomationId="IntelTotalProgressBar"/>
                             <TextBlock x:Name="IntelTotalProgressText"
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,0,0,12"
-                                       Text="No catch-up update is currently required."/>
+                                       Text="No catch-up update is currently required." AutomationProperties.AutomationId="IntelTotalProgressText"/>
 
                             <TextBlock Text="Current-Day Progress"
                                        FontWeight="SemiBold"
@@ -116,11 +116,11 @@
                                          Margin="0,6,0,4"
                                          Minimum="0"
                                          Maximum="100"
-                                         Value="0"/>
+                                         Value="0" AutomationProperties.AutomationId="IntelCurrentDayProgressBar"/>
                             <TextBlock x:Name="IntelCurrentDayProgressText"
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,0,0,0"
-                                       Text="No update currently running."/>
+                                       Text="No update currently running." AutomationProperties.AutomationId="IntelCurrentDayProgressText"/>
                         </StackPanel>
                     </Border>
 
@@ -145,7 +145,7 @@
                                     <TextBlock x:Name="IntelLiveFeedSourceText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="R2Z2"/>
+                                               Text="R2Z2" AutomationProperties.AutomationId="IntelLiveFeedSourceText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -155,7 +155,7 @@
                                     <TextBlock x:Name="IntelLiveFeedStatusText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="Disabled"/>
+                                               Text="Disabled" AutomationProperties.AutomationId="IntelLiveFeedStatusText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -165,7 +165,7 @@
                                     <TextBlock x:Name="IntelLiveFeedEnabledText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No"/>
+                                               Text="No" AutomationProperties.AutomationId="IntelLiveFeedEnabledText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -175,7 +175,7 @@
                                     <TextBlock x:Name="IntelLiveFeedRecentImportsText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="IntelLiveFeedRecentImportsText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -185,7 +185,7 @@
                                     <TextBlock x:Name="IntelLiveFeedNextSequenceText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="Not initialized"/>
+                                               Text="Not initialized" AutomationProperties.AutomationId="IntelLiveFeedNextSequenceText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -195,7 +195,7 @@
                                     <TextBlock x:Name="IntelLiveFeedLastProcessedSequenceText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="None"/>
+                                               Text="None" AutomationProperties.AutomationId="IntelLiveFeedLastProcessedSequenceText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -205,7 +205,7 @@
                                     <TextBlock x:Name="IntelLiveFeedLastSuccessText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No live imports recorded yet."/>
+                                               Text="No live imports recorded yet." AutomationProperties.AutomationId="IntelLiveFeedLastSuccessText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -215,7 +215,7 @@
                                     <TextBlock x:Name="IntelLiveFeedLastCaughtUpText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No caught-up wait recorded yet."/>
+                                               Text="No caught-up wait recorded yet." AutomationProperties.AutomationId="IntelLiveFeedLastCaughtUpText"/>
                                 </StackPanel>
                             </UniformGrid>
 
@@ -227,7 +227,7 @@
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,4,0,0"
                                        TextWrapping="Wrap"
-                                       Text="No live-feed errors recorded."/>
+                                       Text="No live-feed errors recorded." AutomationProperties.AutomationId="IntelLiveFeedLastErrorText"/>
                         </StackPanel>
                     </Border>
 
@@ -248,7 +248,7 @@
                                         Width="200"
                                         Padding="14,6"
                                         Content="Refresh Today's zKill Intel"
-                                        Click="RunTodaysFreshnessButton_Click"/>
+                                        Click="RunTodaysFreshnessButton_Click" AutomationProperties.AutomationId="RunTodaysFreshnessButton"/>
                             </DockPanel>
 
                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
@@ -265,7 +265,7 @@
                                     <TextBlock x:Name="TodaysFreshnessStatusText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="Idle"/>
+                                               Text="Idle" AutomationProperties.AutomationId="TodaysFreshnessStatusText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -275,7 +275,7 @@
                                     <TextBlock x:Name="TodaysFreshnessVisiblePilotsText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="TodaysFreshnessVisiblePilotsText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -285,7 +285,7 @@
                                     <TextBlock x:Name="TodaysFreshnessEntitiesQueriedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="TodaysFreshnessEntitiesQueriedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -295,7 +295,7 @@
                                     <TextBlock x:Name="TodaysFreshnessResultsFoundText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="TodaysFreshnessResultsFoundText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -305,7 +305,7 @@
                                     <TextBlock x:Name="TodaysFreshnessKnownSkippedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="TodaysFreshnessKnownSkippedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -315,7 +315,7 @@
                                     <TextBlock x:Name="TodaysFreshnessImportedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="TodaysFreshnessImportedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -325,7 +325,7 @@
                                     <TextBlock x:Name="TodaysFreshnessFailedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="TodaysFreshnessFailedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -335,7 +335,7 @@
                                     <TextBlock x:Name="TodaysFreshnessLastRunText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No Today's Freshness run recorded yet."/>
+                                               Text="No Today's Freshness run recorded yet." AutomationProperties.AutomationId="TodaysFreshnessLastRunText"/>
                                 </StackPanel>
                             </UniformGrid>
 
@@ -347,7 +347,7 @@
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,4,0,0"
                                        TextWrapping="Wrap"
-                                       Text="Today's Freshness is idle."/>
+                                       Text="Today's Freshness is idle." AutomationProperties.AutomationId="TodaysFreshnessDetailText"/>
 
                             <TextBlock Text="Last Error"
                                        FontWeight="SemiBold"
@@ -357,7 +357,7 @@
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,4,0,0"
                                        TextWrapping="Wrap"
-                                       Text="No Today's Freshness errors recorded."/>
+                                       Text="No Today's Freshness errors recorded." AutomationProperties.AutomationId="TodaysFreshnessLastErrorText"/>
                         </StackPanel>
                     </Border>
 
@@ -378,7 +378,7 @@
                                         Width="210"
                                         Padding="14,6"
                                         Content="Repair Recent Historical Intel"
-                                        Click="RunHistoricalFreshnessButton_Click"/>
+                                        Click="RunHistoricalFreshnessButton_Click" AutomationProperties.AutomationId="RunHistoricalFreshnessButton"/>
                             </DockPanel>
 
                             <TextBlock Style="{StaticResource SettingsLabelStyle}"
@@ -395,7 +395,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessStatusText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="Idle"/>
+                                               Text="Idle" AutomationProperties.AutomationId="HistoricalFreshnessStatusText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -405,7 +405,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessModeText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="Not run yet"/>
+                                               Text="Not run yet" AutomationProperties.AutomationId="HistoricalFreshnessModeText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -415,7 +415,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessVisiblePilotsText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessVisiblePilotsText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -425,7 +425,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessCandidatesConsideredText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessCandidatesConsideredText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -435,7 +435,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessCandidatesSkippedCooldownText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessCandidatesSkippedCooldownText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -445,7 +445,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessPilotsCheckedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessPilotsCheckedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -455,7 +455,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessDaysCheckedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessDaysCheckedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -465,7 +465,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessEntitiesQueriedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessEntitiesQueriedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -475,7 +475,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessResultsFoundText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessResultsFoundText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -485,7 +485,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessKnownSkippedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessKnownSkippedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -495,7 +495,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessImportedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessImportedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,0,8">
@@ -505,7 +505,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessFailedText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="0"/>
+                                               Text="0" AutomationProperties.AutomationId="HistoricalFreshnessFailedText"/>
                                 </StackPanel>
 
                                 <StackPanel Margin="0,0,12,8">
@@ -515,7 +515,7 @@
                                     <TextBlock x:Name="HistoricalFreshnessLastRunText"
                                                Style="{StaticResource SettingsLabelStyle}"
                                                Margin="0,4,0,0"
-                                               Text="No Historical Freshness run recorded yet."/>
+                                               Text="No Historical Freshness run recorded yet." AutomationProperties.AutomationId="HistoricalFreshnessLastRunText"/>
                                 </StackPanel>
                             </UniformGrid>
 
@@ -527,7 +527,7 @@
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,4,0,0"
                                        TextWrapping="Wrap"
-                                       Text="Historical Freshness is idle."/>
+                                       Text="Historical Freshness is idle." AutomationProperties.AutomationId="HistoricalFreshnessDetailText"/>
 
                             <TextBlock Text="Last Error"
                                        FontWeight="SemiBold"
@@ -537,7 +537,7 @@
                                        Style="{StaticResource SettingsLabelStyle}"
                                        Margin="0,4,0,0"
                                        TextWrapping="Wrap"
-                                       Text="No Historical Freshness errors recorded."/>
+                                       Text="No Historical Freshness errors recorded." AutomationProperties.AutomationId="HistoricalFreshnessLastErrorText"/>
                         </StackPanel>
                     </Border>
                 </StackPanel>
@@ -569,7 +569,7 @@
 
                         <TextBlock x:Name="EffectiveMaxKillmailAgeText"
                                    Style="{StaticResource SettingsLabelStyle}"
-                                   Text="Effective max killmail age: 30 days"/>
+                                   Text="Effective max killmail age: 30 days" AutomationProperties.AutomationId="EffectiveMaxKillmailAgeText"/>
 
                         <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                    Margin="0,6,0,4"
@@ -578,7 +578,7 @@
                         <TextBox x:Name="MaxKillmailAgeDaysTextBox"
                                  Margin="0,0,0,10"
                                  Width="140"
-                                 HorizontalAlignment="Left"/>
+                                 HorizontalAlignment="Left" AutomationProperties.AutomationId="MaxKillmailAgeDaysTextBox"/>
 
                         <WrapPanel Margin="0,0,0,12">
                             <Button x:Name="SaveMaxKillmailAgeButton"
@@ -586,14 +586,14 @@
                                     Padding="14,6"
                                     Margin="0,0,10,0"
                                     Content="Save Age"
-                                    Click="SaveMaxKillmailAgeButton_Click"/>
+                                    Click="SaveMaxKillmailAgeButton_Click" AutomationProperties.AutomationId="SaveMaxKillmailAgeButton"/>
 
                             <Button x:Name="UseDefaultMaxKillmailAgeButton"
                                     Width="120"
                                     Padding="14,6"
                                     Margin="0,0,10,0"
                                     Content="Use Default"
-                                    Click="UseDefaultMaxKillmailAgeButton_Click"/>
+                                    Click="UseDefaultMaxKillmailAgeButton_Click" AutomationProperties.AutomationId="UseDefaultMaxKillmailAgeButton"/>
                         </WrapPanel>
 
                         <TextBlock Style="{StaticResource SettingsLabelStyle}"
@@ -606,7 +606,7 @@
                                     Margin="0,0,10,0"
                                     HorizontalAlignment="Left"
                                     Content="Enable KillMail DB Pull"
-                                    Click="EnableKillmailDbPullButton_Click"/>
+                                    Click="EnableKillmailDbPullButton_Click" AutomationProperties.AutomationId="EnableKillmailDbPullButton"/>
                         </WrapPanel>
 
                         <TextBlock Text="Live zKill Feed"
@@ -619,7 +619,7 @@
                                   Content="Enable R2Z2 live zKill feed"
                                   Margin="0,0,0,8"
                                   Checked="EnableLiveZkillFeedCheckBox_Checked"
-                                  Unchecked="EnableLiveZkillFeedCheckBox_Checked"/>
+                                  Unchecked="EnableLiveZkillFeedCheckBox_Checked" AutomationProperties.AutomationId="EnableLiveZkillFeedCheckBox"/>
 
                         <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                    Margin="0,0,0,12"
@@ -636,7 +636,7 @@
                                   Content="Run Background Historical Repair after startup"
                                   Margin="0,0,0,8"
                                   Checked="BackgroundHistoricalRepairEnabledCheckBox_Checked"
-                                  Unchecked="BackgroundHistoricalRepairEnabledCheckBox_Checked"/>
+                                  Unchecked="BackgroundHistoricalRepairEnabledCheckBox_Checked" AutomationProperties.AutomationId="BackgroundHistoricalRepairEnabledCheckBox"/>
 
                         <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                    Margin="0,0,0,12"
@@ -653,7 +653,7 @@
                                   Width="220"
                                   HorizontalAlignment="Left"
                                   Margin="0,0,0,8"
-                                  SelectionChanged="PilotDetailPlacementComboBox_SelectionChanged">
+                                  SelectionChanged="PilotDetailPlacementComboBox_SelectionChanged" AutomationProperties.AutomationId="PilotDetailPlacementComboBox">
                             <ComboBoxItem Content="Auto, prefer right"/>
                             <ComboBoxItem Content="Auto, prefer left"/>
                         </ComboBox>
@@ -669,12 +669,12 @@
 
                         <TextBlock x:Name="KillmailDataPathModeText"
                                    Style="{StaticResource SettingsLabelStyle}"
-                                   Text="Using default LocalAppData path."/>
+                                   Text="Using default LocalAppData path." AutomationProperties.AutomationId="KillmailDataPathModeText"/>
 
                         <TextBlock x:Name="EffectiveKillmailDataPathText"
                                    Style="{StaticResource SettingsLabelStyle}"
                                    TextWrapping="Wrap"
-                                   Text="Effective path: --"/>
+                                   Text="Effective path: --" AutomationProperties.AutomationId="EffectiveKillmailDataPathText"/>
 
                         <TextBlock Style="{StaticResource SettingsLabelStyle}"
                                    Margin="0,6,0,4"
@@ -684,7 +684,7 @@
                                  Margin="0,0,0,10"
                                  Width="420"
                                  MaxWidth="620"
-                                 HorizontalAlignment="Left"/>
+                                 HorizontalAlignment="Left" AutomationProperties.AutomationId="KillmailDataRootPathTextBox"/>
 
                         <WrapPanel>
                             <Button x:Name="SaveKillmailPathButton"
@@ -692,14 +692,14 @@
                                     Padding="14,6"
                                     Margin="0,0,10,0"
                                     Content="Save Path"
-                                    Click="SaveKillmailPathButton_Click"/>
+                                    Click="SaveKillmailPathButton_Click" AutomationProperties.AutomationId="SaveKillmailPathButton"/>
 
                             <Button x:Name="UseDefaultKillmailPathButton"
                                     Width="120"
                                     Padding="14,6"
                                     Margin="0,0,10,0"
                                     Content="Use Default"
-                                    Click="UseDefaultKillmailPathButton_Click"/>
+                                    Click="UseDefaultKillmailPathButton_Click" AutomationProperties.AutomationId="UseDefaultKillmailPathButton"/>
                         </WrapPanel>
 
                         <TextBlock Style="{StaticResource SettingsLabelStyle}"

--- a/PitmastersGrill/Views/PilotDetailWindow.xaml
+++ b/PitmastersGrill/Views/PilotDetailWindow.xaml
@@ -59,66 +59,66 @@
                            FontWeight="SemiBold"
                            Foreground="{DynamicResource HeaderTextBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,4"/>
+                           Margin="0,0,0,4" AutomationProperties.AutomationId="PilotNameText"/>
 
                 <TextBlock x:Name="AffiliationText"
                            Foreground="{DynamicResource BodyTextBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,2"/>
+                           Margin="0,0,0,2" AutomationProperties.AutomationId="AffiliationText"/>
 
                 <TextBlock x:Name="ActivityText"
                            Foreground="{DynamicResource MutedTextBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,2"/>
+                           Margin="0,0,0,2" AutomationProperties.AutomationId="ActivityText"/>
 
                 <TextBlock x:Name="KillLossText"
                            Foreground="{DynamicResource MutedTextBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,10"/>
+                           Margin="0,0,0,10" AutomationProperties.AutomationId="KillLossText"/>
 
                 <WrapPanel Margin="0,0,0,8">
                     <Button x:Name="KnownCynoOverrideLink"
                             Style="{StaticResource DetailLinkButtonStyle}"
                             Content="Known-Cyno Override"
-                            Click="KnownCynoOverrideLink_Click"/>
+                            Click="KnownCynoOverrideLink_Click" AutomationProperties.AutomationId="KnownCynoOverrideLink"/>
                     <Button x:Name="BaitOverrideLink"
                             Style="{StaticResource DetailLinkButtonStyle}"
                             Content="Bait"
-                            Click="BaitOverrideLink_Click"/>
+                            Click="BaitOverrideLink_Click" AutomationProperties.AutomationId="BaitOverrideLink"/>
                     <Button x:Name="WatchPilotLink"
                             Style="{StaticResource DetailLinkButtonStyle}"
                             Content="Watch"
-                            Click="WatchPilotLink_Click"/>
+                            Click="WatchPilotLink_Click" AutomationProperties.AutomationId="WatchPilotLink"/>
                 </WrapPanel>
 
                 <TextBlock x:Name="BaitSignalText"
                            FontWeight="SemiBold"
                            Foreground="{DynamicResource BoardSignalBaitBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,2"/>
+                           Margin="0,0,0,2" AutomationProperties.AutomationId="BaitSignalText"/>
 
                 <TextBlock x:Name="CynoSignalText"
                            FontWeight="SemiBold"
                            Foreground="{DynamicResource AccentAshBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,2"/>
+                           Margin="0,0,0,2" AutomationProperties.AutomationId="CynoSignalText"/>
 
                 <TextBlock x:Name="EvidenceText"
                            Foreground="{DynamicResource BodyTextBrush}"
                            TextWrapping="Wrap"
                            TextTrimming="CharacterEllipsis"
-                           Margin="0,0,0,2"/>
+                           Margin="0,0,0,2" AutomationProperties.AutomationId="EvidenceText"/>
 
                 <TextBlock x:Name="LimitationsText"
                            Foreground="{DynamicResource MutedTextBrush}"
                            TextWrapping="Wrap"
-                           Margin="0,0,0,8"/>
+                           Margin="0,0,0,8" AutomationProperties.AutomationId="LimitationsText"/>
 
                 <TextBlock x:Name="BottomFreshnessText"
                            Foreground="{DynamicResource MutedTextBrush}"
                            FontSize="11"
                            TextWrapping="Wrap"
-                           Margin="0,2,0,0"/>
+                           Margin="0,2,0,0" AutomationProperties.AutomationId="BottomFreshnessText"/>
             </StackPanel>
 
             <WrapPanel Grid.Row="1"
@@ -127,23 +127,23 @@
                 <Button x:Name="IgnorePilotLink"
                         Style="{StaticResource DetailLinkButtonStyle}"
                         Content="Ignore Pilot"
-                        Click="IgnorePilotLink_Click"/>
+                        Click="IgnorePilotLink_Click" AutomationProperties.AutomationId="IgnorePilotLink"/>
                 <Button x:Name="IgnoreCorpLink"
                         Style="{StaticResource DetailLinkButtonStyle}"
                         Content="Ignore Corp"
-                        Click="IgnoreCorpLink_Click"/>
+                        Click="IgnoreCorpLink_Click" AutomationProperties.AutomationId="IgnoreCorpLink"/>
                 <Button x:Name="IgnoreAllianceLink"
                         Style="{StaticResource DetailLinkButtonStyle}"
                         Content="Ignore Alliance"
-                        Click="IgnoreAllianceLink_Click"/>
+                        Click="IgnoreAllianceLink_Click" AutomationProperties.AutomationId="IgnoreAllianceLink"/>
                 <Button x:Name="OpenZkillLink"
                         Style="{StaticResource DetailLinkButtonStyle}"
                         Content="Open zKill"
-                        Click="OpenZkillLink_Click"/>
+                        Click="OpenZkillLink_Click" AutomationProperties.AutomationId="OpenZkillLink"/>
                 <Button x:Name="CloseLink"
                         Style="{StaticResource DetailLinkButtonStyle}"
                         Content="Close"
-                        Click="CloseLink_Click"/>
+                        Click="CloseLink_Click" AutomationProperties.AutomationId="CloseLink"/>
             </WrapPanel>
         </Grid>
     </Border>

--- a/PitmastersGrill/Views/PilotNotesWindow.xaml
+++ b/PitmastersGrill/Views/PilotNotesWindow.xaml
@@ -27,7 +27,7 @@
                        FontSize="18"
                        FontWeight="SemiBold"
                        Foreground="{DynamicResource HeaderTextBrush}"
-                       Margin="0,0,0,8"/>
+                       Margin="0,0,0,8" AutomationProperties.AutomationId="PilotNameText"/>
 
             <TextBox x:Name="NotesTextBox"
                      Grid.Row="1"
@@ -35,7 +35,7 @@
                      TextWrapping="Wrap"
                      VerticalScrollBarVisibility="Auto"
                      MinHeight="120"
-                     Margin="0,0,0,10"/>
+                     Margin="0,0,0,10" AutomationProperties.AutomationId="NotesTextBox"/>
 
             <WrapPanel Grid.Row="2"
                        HorizontalAlignment="Right">

--- a/PitmastersGrill/Views/StartupSplashWindow.xaml
+++ b/PitmastersGrill/Views/StartupSplashWindow.xaml
@@ -35,14 +35,14 @@
                        FontSize="16"
                        FontWeight="SemiBold"
                        Foreground="White"
-                       TextWrapping="Wrap" />
+                       TextWrapping="Wrap"  AutomationProperties.AutomationId="StatusTextBlock"/>
 
             <TextBlock Grid.Row="4"
                        x:Name="DetailTextBlock"
                        Text="Preparing startup update state."
                        FontSize="13"
                        Foreground="#D0D0D0"
-                       TextWrapping="Wrap" />
+                       TextWrapping="Wrap"  AutomationProperties.AutomationId="DetailTextBlock"/>
 
             <ProgressBar Grid.Row="6"
                          x:Name="ProgressBarControl"
@@ -50,7 +50,7 @@
                          Minimum="0"
                          Maximum="100"
                          Value="0"
-                         IsIndeterminate="False" />
+                         IsIndeterminate="False"  AutomationProperties.AutomationId="ProgressBarControl"/>
 
             <TextBlock Grid.Row="7"
                        x:Name="ExceptionTextBlock"
@@ -60,7 +60,7 @@
                        FontWeight="SemiBold"
                        Foreground="#FFCC66"
                        TextWrapping="Wrap"
-                       Visibility="Collapsed" />
+                       Visibility="Collapsed"  AutomationProperties.AutomationId="ExceptionTextBlock"/>
         </Grid>
     </Border>
 </Window>

--- a/scripts/Invoke-PmgSmokeTest.ps1
+++ b/scripts/Invoke-PmgSmokeTest.ps1
@@ -1,0 +1,2226 @@
+<#
+
+.SYNOPSIS
+
+Runs PMG local regression/smoke validation checks.
+
+
+
+.DESCRIPTION
+
+This script automates PMG validation layers that are feasible from a local Windows development machine:
+
+- repo/working-tree visibility
+
+- explicit dotnet test/build paths
+
+- git diff whitespace check
+
+- MainWindow line-count reporting
+
+- WPF process launch
+
+- responsiveness/no-hang sampling
+
+- normal close attempt
+
+- optional UI Automation regression smoke
+
+- recent PMG log discovery and failure tail capture
+
+
+
+The optional -FullUiSmoke mode exercises visible UI controls through Windows UI Automation. It is intended
+
+as a practical replacement for repeated manual smoke checks, while still avoiding destructive operations.
+
+
+
+.PARAMETER RepoRoot
+
+Repository root. Defaults to the parent folder of this script's directory.
+
+
+
+.PARAMETER ResponsivenessSeconds
+
+How long to sample the running WPF process for responsiveness.
+
+
+
+.PARAMETER SampleIntervalSeconds
+
+Seconds between responsiveness samples.
+
+
+
+.PARAMETER RequireClean
+
+Fail if the Git working tree has changes.
+
+
+
+.PARAMETER EnforceLineGate
+
+Fail if MainWindow.xaml.cs or MainWindow.xaml exceeds the configured line thresholds.
+
+By default line counts are reported but not enforced because v1.4.0 refactor work may be in progress.
+
+
+
+.PARAMETER FullUiSmoke
+
+Runs the deeper UI Automation smoke pass after startup. This navigates tabs, toggles reversible settings,
+
+exercises safe refresh buttons, and invokes confirmable maintenance buttons only far enough to cancel/no the dialog.
+
+
+
+.PARAMETER ExerciseConfirmableActions
+
+Allows -FullUiSmoke to click confirmation-based maintenance buttons and cancel/No the resulting dialog.
+
+Without this flag, those buttons are only checked for presence/enabled state.
+
+
+
+.PARAMETER UiInventory
+
+Writes a UI Automation inventory to the transcript and skips no checks by itself. Useful for adding stable selectors.
+
+
+
+.PARAMETER KeepAppOpen
+
+Leaves the app running at the end of validation for manual inspection.
+
+
+
+.PARAMETER SkipDotNet
+
+Skip dotnet test/build.
+
+
+
+.PARAMETER SkipDiffCheck
+
+Skip git diff --check.
+
+
+
+.PARAMETER SkipLaunch
+
+Skip WPF launch/responsiveness/close checks.
+
+
+
+.EXAMPLE
+
+.\scripts\Invoke-PmgSmokeTest.ps1
+
+
+
+.EXAMPLE
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30
+
+
+
+.EXAMPLE
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ExerciseConfirmableActions
+
+#>
+
+
+
+[CmdletBinding()]
+
+param(
+
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+
+    [int]$ResponsivenessSeconds = 60,
+
+    [int]$SampleIntervalSeconds = 5,
+
+    [switch]$RequireClean,
+
+    [switch]$EnforceLineGate,
+
+    [int]$MainWindowCodeBehindMaxLines = 2000,
+
+    [int]$MainWindowXamlMaxLines = 2000,
+
+    [switch]$FullUiSmoke,
+
+    [switch]$ExerciseConfirmableActions,
+
+    [switch]$UiInventory,
+
+    [switch]$KeepAppOpen,
+    [switch]$SkipBoardPopulationSmoke,
+    [string]$BoardFixturePath = "",
+    [int]$BoardPopulationTimeoutSeconds = 240,
+
+    [switch]$SkipDotNet,
+
+    [switch]$SkipDiffCheck,
+
+    [switch]$SkipLaunch
+
+)
+
+
+
+Set-StrictMode -Version Latest
+
+$ErrorActionPreference = "Stop"
+
+
+
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+$script:Warnings = New-Object System.Collections.Generic.List[string]
+
+$script:UiSmokeFindings = New-Object System.Collections.Generic.List[string]
+
+
+
+function Write-Section {
+
+    param([Parameter(Mandatory)][string]$Title)
+
+    Write-Host ""
+
+    Write-Host "== $Title =="
+
+}
+
+
+
+function Add-Failure {
+
+    param([Parameter(Mandatory)][string]$Message)
+
+    $script:Failures.Add($Message) | Out-Null
+
+    Write-Host "[FAIL] $Message" -ForegroundColor Red
+
+}
+
+
+
+function Add-Warning {
+
+    param([Parameter(Mandatory)][string]$Message)
+
+    $script:Warnings.Add($Message) | Out-Null
+
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+
+}
+
+
+
+function Add-Pass {
+
+    param([Parameter(Mandatory)][string]$Message)
+
+    Write-Host "[PASS] $Message" -ForegroundColor Green
+
+}
+
+
+
+function Add-UiFinding {
+
+    param([Parameter(Mandatory)][string]$Message)
+
+    $script:UiSmokeFindings.Add($Message) | Out-Null
+
+    Write-Host "[UI] $Message"
+
+}
+
+
+
+function Assert-Path {
+
+    param(
+
+        [Parameter(Mandatory)][string]$Path,
+
+        [Parameter(Mandatory)][string]$Description
+
+    )
+
+
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+
+        throw "$Description not found: $Path"
+
+    }
+
+}
+
+
+
+function Invoke-NativeChecked {
+
+    param(
+
+        [Parameter(Mandatory)][string]$FilePath,
+
+        [Parameter(Mandatory)][string[]]$Arguments,
+
+        [Parameter(Mandatory)][string]$Description,
+
+        [string]$WorkingDirectory = $RepoRoot
+
+    )
+
+
+
+    Write-Host ""
+
+    Write-Host "> $FilePath $($Arguments -join ' ')"
+
+
+
+    Push-Location $WorkingDirectory
+
+    try {
+
+        & $FilePath @Arguments
+
+        $exitCode = $LASTEXITCODE
+
+    }
+
+    finally {
+
+        Pop-Location
+
+    }
+
+
+
+    if ($exitCode -ne 0) {
+
+        Add-Failure "$Description failed with exit code $exitCode."
+
+        return $false
+
+    }
+
+
+
+    Add-Pass "$Description completed successfully."
+
+    return $true
+
+}
+
+
+
+function Get-FileLineCount {
+
+    param([Parameter(Mandatory)][string]$Path)
+
+    return (Get-Content -LiteralPath $Path).Count
+
+}
+
+
+
+function Get-RecentPmgLogs {
+
+    $logRoots = @(
+
+        (Join-Path $env:LOCALAPPDATA "PitmastersGrill"),
+
+        (Join-Path $env:APPDATA "PitmastersGrill"),
+
+        $RepoRoot
+
+    ) | Where-Object { $_ -and (Test-Path -LiteralPath $_) }
+
+
+
+    $cutoff = (Get-Date).AddHours(-4)
+
+    $found = foreach ($root in $logRoots) {
+
+        Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction SilentlyContinue |
+
+            Where-Object {
+
+                $_.LastWriteTime -ge $cutoff -and
+
+                ($_.Name -match 'log|trace|diagnostic')
+
+            }
+
+    }
+
+
+
+    return $found | Sort-Object LastWriteTime -Descending
+
+}
+
+
+
+function Show-RecentLogs {
+
+    param([int]$Tail = 80)
+
+
+
+    Write-Section "Recent PMG logs"
+
+    $logs = @(Get-RecentPmgLogs | Select-Object -First 10)
+
+
+
+    if ($logs.Count -eq 0) {
+
+        Add-Warning "No recent PMG log/trace/diagnostic files found in the expected locations."
+
+        return
+
+    }
+
+
+
+    foreach ($log in $logs) {
+
+        Write-Host ("{0:u} | {1,8} bytes | {2}" -f $log.LastWriteTime, $log.Length, $log.FullName)
+
+    }
+
+
+
+    if ($script:Failures.Count -gt 0) {
+
+        $latest = $logs[0]
+
+        Write-Host ""
+
+        Write-Host "--- Tail of newest log: $($latest.FullName) ---"
+
+        try {
+
+            Get-Content -LiteralPath $latest.FullName -Tail $Tail
+
+        }
+
+        catch {
+
+            Add-Warning "Failed to tail newest log: $($_.Exception.Message)"
+
+        }
+
+    }
+
+}
+
+
+
+function Initialize-UiAutomation {
+
+    try {
+
+        Add-Type -AssemblyName UIAutomationClient -ErrorAction Stop
+
+        Add-Type -AssemblyName UIAutomationTypes -ErrorAction Stop
+
+        Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
+
+        return $true
+
+    }
+
+    catch {
+
+        Add-Failure "Failed to load UI Automation assemblies: $($_.Exception.Message)"
+
+        return $false
+
+    }
+
+}
+
+
+
+function Get-MainAutomationWindow {
+
+    param(
+
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+
+        [int]$TimeoutSeconds = 20
+
+    )
+
+
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+
+
+    while ((Get-Date) -lt $deadline) {
+
+        $Process.Refresh()
+
+        if ($Process.HasExited) {
+
+            return $null
+
+        }
+
+
+
+        $handle = $Process.MainWindowHandle
+
+        if ($handle -ne [IntPtr]::Zero) {
+
+            try {
+
+                return [System.Windows.Automation.AutomationElement]::FromHandle($handle)
+
+            }
+
+            catch {
+
+                Start-Sleep -Milliseconds 300
+
+            }
+
+        }
+
+
+
+        Start-Sleep -Milliseconds 300
+
+    }
+
+
+
+    return $null
+
+}
+
+
+
+function Get-ControlTypeName {
+
+    param([Parameter(Mandatory)]$ControlType)
+
+    if ($null -eq $ControlType) { return "" }
+
+    return $ControlType.ProgrammaticName -replace '^ControlType\.', ''
+
+}
+
+
+
+function Get-ElementSummary {
+
+    param([Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Element)
+
+    $name = $Element.Current.Name
+
+    $automationId = $Element.Current.AutomationId
+
+    $type = Get-ControlTypeName $Element.Current.ControlType
+
+    return "Type='$type' Name='$name' AutomationId='$automationId' Enabled=$($Element.Current.IsEnabled)"
+
+}
+
+
+
+function Find-ElementsByControlType {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)]$ControlType
+
+    )
+
+
+
+    $condition = [System.Windows.Automation.PropertyCondition]::new(
+
+        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+
+        $ControlType)
+
+
+
+    return @($Root.FindAll([System.Windows.Automation.TreeScope]::Descendants, $condition))
+
+}
+
+
+
+function Find-ElementByNames {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)][string[]]$Names,
+
+        [object[]]$ControlTypes = @()
+
+    )
+
+
+
+    $candidates = New-Object System.Collections.Generic.List[System.Windows.Automation.AutomationElement]
+
+
+
+    if ($ControlTypes.Count -gt 0) {
+
+        foreach ($controlType in $ControlTypes) {
+
+            foreach ($element in (Find-ElementsByControlType -Root $Root -ControlType $controlType)) {
+
+                $candidates.Add($element) | Out-Null
+
+            }
+
+        }
+
+    }
+
+    else {
+
+        $trueCondition = [System.Windows.Automation.Condition]::TrueCondition
+
+        foreach ($element in @($Root.FindAll([System.Windows.Automation.TreeScope]::Descendants, $trueCondition))) {
+
+            $candidates.Add($element) | Out-Null
+
+        }
+
+    }
+
+
+
+    foreach ($name in $Names) {
+
+        foreach ($element in $candidates) {
+
+            if ($element.Current.Name -eq $name -or $element.Current.AutomationId -eq $name) {
+
+                return $element
+
+            }
+
+        }
+
+    }
+
+
+
+    foreach ($name in $Names) {
+
+        foreach ($element in $candidates) {
+
+            if (($element.Current.Name -like "*$name*") -or ($element.Current.AutomationId -like "*$name*")) {
+
+                return $element
+
+            }
+
+        }
+
+    }
+
+
+
+    return $null
+
+}
+
+
+
+function Get-PatternOrNull {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Element,
+
+        [Parameter(Mandatory)]$PatternId
+
+    )
+
+
+
+    $pattern = $null
+
+    if ($Element.TryGetCurrentPattern($PatternId, [ref]$pattern)) {
+
+        return $pattern
+
+    }
+
+
+
+    return $null
+
+}
+
+
+
+function Invoke-Element {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Element,
+
+        [Parameter(Mandatory)][string]$Description
+
+    )
+
+
+
+    $invoke = Get-PatternOrNull -Element $Element -PatternId ([System.Windows.Automation.InvokePattern]::Pattern)
+
+    if ($null -ne $invoke) {
+
+        $invoke.Invoke()
+
+        Add-Pass "Invoked $Description."
+
+        Start-Sleep -Milliseconds 600
+
+        return $true
+
+    }
+
+
+
+    $selection = Get-PatternOrNull -Element $Element -PatternId ([System.Windows.Automation.SelectionItemPattern]::Pattern)
+
+    if ($null -ne $selection) {
+
+        $selection.Select()
+
+        Add-Pass "Selected $Description."
+
+        Start-Sleep -Milliseconds 600
+
+        return $true
+
+    }
+
+
+
+    Add-Failure "Element does not support Invoke or SelectionItem pattern: $Description; $(Get-ElementSummary $Element)"
+
+    return $false
+
+}
+
+
+
+
+function Try-Select-TabByName {
+    param(
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+        [Parameter(Mandatory)][string[]]$Names,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    $tab = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::TabItem)
+    if ($null -eq $tab) {
+        return $false
+    }
+
+    return Invoke-Element -Element $tab -Description "tab '$($tab.Current.Name)' for $Description"
+}
+
+
+function Select-SettingsSubTab {
+    param(
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+        [Parameter(Mandatory)][string[]]$Names,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    Select-TabByName -Root $Root -Names @("Settings", "SettingsTab") -Description "Settings tab before $Description" | Out-Null
+    Start-Sleep -Milliseconds 400
+
+    if (Try-Select-TabByName -Root $Root -Names $Names -Description $Description) {
+        Start-Sleep -Milliseconds 400
+        return $true
+    }
+
+    Add-Warning "Could not select Settings subtab for ${Description}. Names tried: $($Names -join ', ')"
+    return $false
+}
+
+function Select-DiagnosticsArea {
+    param(
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    $diagnosticsNames = @(
+        "DiagnosticsSupportTab",
+        "Diagnostics",
+        "Diagnostics & Support",
+        "Diagnostics/Support",
+        "Logs & Diagnostics",
+        "Support",
+        "Logs",
+        "Troubleshooting"
+    )
+
+    if (Try-Select-TabByName -Root $Root -Names $diagnosticsNames -Description $Description) {
+        return $true
+    }
+
+    # Current PMG places Diagnostics under the Settings tab; older/alternate layouts may place it under Help.
+    $parentTabCandidates = @(
+        @{ Names = @("Settings", "SettingsTab"); Description = "Settings tab before $Description" },
+        @{ Names = @("Help", "HelpTab"); Description = "Help tab before $Description" }
+    )
+
+    foreach ($parent in $parentTabCandidates) {
+        if (Try-Select-TabByName -Root $Root -Names $parent.Names -Description $parent.Description) {
+            Start-Sleep -Milliseconds 500
+
+            if (Try-Select-TabByName -Root $Root -Names $diagnosticsNames -Description $Description) {
+                return $true
+            }
+        }
+    }
+
+    Add-Failure "Could not find Diagnostics/Support area for ${Description}. Tried top-level, Settings-nested, and Help-nested diagnostics names: $($diagnosticsNames -join ', ')"
+    return $false
+}
+
+function Select-TabByName {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)][string[]]$Names,
+
+        [Parameter(Mandatory)][string]$Description
+
+    )
+
+
+
+    $tab = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::TabItem)
+
+    if ($null -eq $tab) {
+
+        Add-Failure "Could not find tab for $Description. Names tried: $($Names -join ', ')"
+
+        return $false
+
+    }
+
+
+
+    return Invoke-Element -Element $tab -Description "tab '$($tab.Current.Name)' for $Description"
+
+}
+
+
+
+function Get-AppDialogWindows {
+
+    param(
+
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$MainWindow
+
+    )
+
+
+
+    $processCondition = [System.Windows.Automation.PropertyCondition]::new(
+
+        [System.Windows.Automation.AutomationElement]::ProcessIdProperty,
+
+        $Process.Id)
+
+    $windowCondition = [System.Windows.Automation.PropertyCondition]::new(
+
+        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+
+        [System.Windows.Automation.ControlType]::Window)
+
+    $condition = [System.Windows.Automation.AndCondition]::new($processCondition, $windowCondition)
+
+
+
+    $windows = @([System.Windows.Automation.AutomationElement]::RootElement.FindAll(
+
+        [System.Windows.Automation.TreeScope]::Children,
+
+        $condition))
+
+
+
+    return $windows | Where-Object { $_.Current.NativeWindowHandle -ne $MainWindow.Current.NativeWindowHandle }
+
+}
+
+
+
+function Dismiss-AppDialogs {
+
+    param(
+
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$MainWindow,
+
+        [string[]]$PreferredButtons = @("No", "Cancel", "OK", "Close")
+
+    )
+
+
+
+    $dismissed = 0
+
+
+
+    for ($attempt = 1; $attempt -le 8; $attempt++) {
+
+        Start-Sleep -Milliseconds 300
+
+        $dialogs = @(Get-AppDialogWindows -Process $Process -MainWindow $MainWindow)
+
+
+
+        if ($dialogs.Count -eq 0) {
+
+            break
+
+        }
+
+
+
+        foreach ($dialog in $dialogs) {
+
+            Write-Host "Dialog detected: $(Get-ElementSummary $dialog)"
+
+            $button = Find-ElementByNames -Root $dialog -Names $PreferredButtons -ControlTypes @([System.Windows.Automation.ControlType]::Button)
+
+
+
+            if ($null -ne $button) {
+
+                Invoke-Element -Element $button -Description "dialog button '$($button.Current.Name)'" | Out-Null
+
+                $dismissed++
+
+            }
+
+            else {
+
+                Add-Warning "Dialog appeared but no preferred dismiss button was found. Sending Escape. Dialog: $(Get-ElementSummary $dialog)"
+
+                [System.Windows.Forms.SendKeys]::SendWait("{ESC}")
+
+                $dismissed++
+
+            }
+
+        }
+
+    }
+
+
+
+    return $dismissed
+
+}
+
+
+
+function Invoke-ButtonByNames {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)][string[]]$Names,
+
+        [Parameter(Mandatory)][string]$Description,
+
+        [switch]$Required
+
+    )
+
+
+
+    $button = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::Button)
+
+    if ($null -eq $button) {
+
+        $message = "Button not found for $Description. Names tried: $($Names -join ', ')"
+
+        if ($Required) { Add-Failure $message } else { Add-Warning $message }
+
+        return $false
+
+    }
+
+
+
+    if (-not $button.Current.IsEnabled) {
+
+        Add-Warning "Button is present but disabled for ${Description}: $(Get-ElementSummary $button)"
+
+        return $false
+
+    }
+
+
+
+    return Invoke-Element -Element $button -Description "button '$($button.Current.Name)' for $Description"
+
+}
+
+
+
+function Assert-ButtonPresent {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)][string[]]$Names,
+
+        [Parameter(Mandatory)][string]$Description
+
+    )
+
+
+
+    $button = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::Button)
+
+    if ($null -eq $button) {
+
+        Add-Failure "Expected button not found for $Description. Names tried: $($Names -join ', ')"
+
+        return $false
+
+    }
+
+
+
+    Add-Pass "Found button for ${Description}: $(Get-ElementSummary $button)"
+
+    return $true
+
+}
+
+
+
+function Toggle-CheckBoxAndRestore {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)][string[]]$Names,
+
+        [Parameter(Mandatory)][string]$Description,
+
+        [switch]$Required
+
+    )
+
+
+
+    $box = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::CheckBox)
+
+    if ($null -eq $box) {
+
+        $message = "Checkbox not found for $Description. Names tried: $($Names -join ', ')"
+
+        if ($Required) { Add-Failure $message } else { Add-Warning $message }
+
+        return
+
+    }
+
+
+
+    $toggle = Get-PatternOrNull -Element $box -PatternId ([System.Windows.Automation.TogglePattern]::Pattern)
+
+    if ($null -eq $toggle) {
+
+        Add-Failure "Checkbox does not support TogglePattern for ${Description}: $(Get-ElementSummary $box)"
+
+        return
+
+    }
+
+
+
+    $original = $toggle.Current.ToggleState
+
+    Add-UiFinding "$Description original state: $original"
+
+
+
+    $toggle.Toggle()
+
+    Start-Sleep -Milliseconds 800
+
+    $box = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::CheckBox)
+
+    $afterFirst = (Get-PatternOrNull -Element $box -PatternId ([System.Windows.Automation.TogglePattern]::Pattern)).Current.ToggleState
+
+    Add-UiFinding "$Description after toggle: $afterFirst"
+
+
+
+    $toggle = Get-PatternOrNull -Element $box -PatternId ([System.Windows.Automation.TogglePattern]::Pattern)
+
+    $toggle.Toggle()
+
+    Start-Sleep -Milliseconds 800
+
+    $box = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::CheckBox)
+
+    $final = (Get-PatternOrNull -Element $box -PatternId ([System.Windows.Automation.TogglePattern]::Pattern)).Current.ToggleState
+
+    Add-UiFinding "$Description restored state: $final"
+
+
+
+    if ($final -ne $original) {
+
+        Add-Failure "$Description did not restore to original state. Original=$original Final=$final"
+
+    }
+
+    else {
+
+        Add-Pass "$Description toggled and restored."
+
+    }
+
+}
+
+
+
+function Adjust-SliderAndRestore {
+
+    param(
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+
+        [Parameter(Mandatory)][string[]]$Names,
+
+        [Parameter(Mandatory)][string]$Description,
+
+        [double]$Delta = -5
+
+    )
+
+
+
+    $slider = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::Slider)
+
+    if ($null -eq $slider) {
+
+        Add-Warning "Slider not found for $Description. Names tried: $($Names -join ', ')"
+
+        return
+
+    }
+
+
+
+    $range = Get-PatternOrNull -Element $slider -PatternId ([System.Windows.Automation.RangeValuePattern]::Pattern)
+
+    if ($null -eq $range) {
+
+        Add-Failure "Slider does not support RangeValuePattern for ${Description}: $(Get-ElementSummary $slider)"
+
+        return
+
+    }
+
+
+
+    $original = [double]$range.Current.Value
+
+    $minimum = [double]$range.Current.Minimum
+
+    $maximum = [double]$range.Current.Maximum
+
+    $target = $original + $Delta
+
+
+
+    if ($target -lt $minimum) { $target = [Math]::Min($maximum, $original + [Math]::Abs($Delta)) }
+
+    if ($target -gt $maximum) { $target = [Math]::Max($minimum, $original - [Math]::Abs($Delta)) }
+
+
+
+    Add-UiFinding "$Description original value: $original; target value: $target"
+
+    $range.SetValue($target)
+
+    Start-Sleep -Milliseconds 800
+
+
+
+    $slider = Find-ElementByNames -Root $Root -Names $Names -ControlTypes @([System.Windows.Automation.ControlType]::Slider)
+
+    $range = Get-PatternOrNull -Element $slider -PatternId ([System.Windows.Automation.RangeValuePattern]::Pattern)
+
+    $range.SetValue($original)
+
+    Start-Sleep -Milliseconds 800
+
+
+
+    Add-Pass "$Description adjusted and restored."
+
+}
+
+
+
+function Write-UiInventory {
+
+    param([Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root)
+
+
+
+    Write-Section "UI Automation inventory"
+
+    $types = @(
+
+        [System.Windows.Automation.ControlType]::TabItem,
+
+        [System.Windows.Automation.ControlType]::Button,
+
+        [System.Windows.Automation.ControlType]::CheckBox,
+
+        [System.Windows.Automation.ControlType]::ComboBox,
+
+        [System.Windows.Automation.ControlType]::Slider,
+
+        [System.Windows.Automation.ControlType]::Edit,
+
+        [System.Windows.Automation.ControlType]::Text
+
+    )
+
+
+
+    foreach ($type in $types) {
+
+        $elements = @(Find-ElementsByControlType -Root $Root -ControlType $type)
+
+        Write-Host "-- $(Get-ControlTypeName $type): $($elements.Count) --"
+
+        foreach ($element in ($elements | Select-Object -First 200)) {
+
+            Write-Host (Get-ElementSummary $element)
+
+        }
+
+    }
+
+}
+
+
+
+function Invoke-FullUiSmoke {
+
+    param(
+
+        [Parameter(Mandatory)][System.Diagnostics.Process]$Process,
+
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$MainWindow
+
+    )
+
+
+
+    Write-Section "Full UI Automation smoke"
+
+
+
+    if ($UiInventory) {
+
+        Write-UiInventory -Root $MainWindow
+
+    }
+
+
+
+    # Top-level tab navigation. Names include fallbacks because visible labels may evolve.
+
+    Select-TabByName -Root $MainWindow -Names @("Grill", "Pilot Board", "Board") -Description "Grill tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Analysis") -Description "Analysis tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Intel", "Public Data", "Intel/Public Data") -Description "Intel/Public Data tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Intel Status", "Status") -Description "Intel Status nested tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Config", "Intel Config") -Description "Intel Config nested tab" | Out-Null
+
+    Select-DiagnosticsArea -Root $MainWindow -Description "Diagnostics tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Settings") -Description "Settings tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Help") -Description "Help tab" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Grill", "Pilot Board", "Board") -Description "return to Grill tab" | Out-Null
+
+
+
+
+
+    if (-not $SkipBoardPopulationSmoke) {
+
+        Test-BoardPopulationFromFixture -Root $MainWindow -FixturePath $effectiveBoardFixturePath -TimeoutSeconds $BoardPopulationTimeoutSeconds
+
+    }
+
+    else {
+
+        Add-Warning "Skipping board fixture population because -SkipBoardPopulationSmoke was specified."
+
+    }
+    # Safe reversible settings checks. Missing names are warnings unless essential.
+    Select-SettingsSubTab -Root $MainWindow -Names @(
+        "Display",
+        "Appearance",
+        "General",
+        "Preferences",
+        "Settings"
+    ) -Description "appearance/general settings subtab" | Out-Null
+
+    Toggle-CheckBoxAndRestore -Root $MainWindow -Names @(
+        "DarkModeCheckBox",
+        "Dark Mode",
+        "Dark mode"
+    ) -Description "Dark mode setting"
+
+    Toggle-CheckBoxAndRestore -Root $MainWindow -Names @(
+        "AlwaysOnTopCheckBox",
+        "Always on top",
+        "Always On Top"
+    ) -Description "Always-on-top setting"
+
+    Adjust-SliderAndRestore -Root $MainWindow -Names @(
+        "WindowOpacitySlider",
+        "Window opacity",
+        "Opacity"
+    ) -Description "Window opacity setting"
+
+    Select-SettingsSubTab -Root $MainWindow -Names @(
+        "Board",
+        "Board Display",
+        "Grill Board",
+        "Columns",
+        "Layout",
+        "Display"
+    ) -Description "board display settings subtab" | Out-Null
+
+    Toggle-CheckBoxAndRestore -Root $MainWindow -Names @(
+        "ShowBoardGridLinesCheckBox",
+        "Show grid lines",
+        "Grid lines"
+    ) -Description "Board grid lines setting"
+
+    Select-TabByName -Root $MainWindow -Names @("Intel", "Public Data", "Intel/Public Data") -Description "Intel/Public Data tab for reversible Intel settings" | Out-Null
+
+    Select-TabByName -Root $MainWindow -Names @("Config", "Intel Config") -Description "Intel Config nested tab" | Out-Null
+
+    Toggle-CheckBoxAndRestore -Root $MainWindow -Names @("Enable live zKill feed", "Live zKill", "R2Z2", "EnableLiveZkillFeedCheckBox") -Description "live zKill/R2Z2 setting"
+
+    Toggle-CheckBoxAndRestore -Root $MainWindow -Names @("Background historical repair", "Historical repair", "BackgroundHistoricalRepairEnabledCheckBox") -Description "background historical repair setting"
+
+
+
+    # Safe refresh buttons.
+
+    Select-DiagnosticsArea -Root $MainWindow -Description "Diagnostics tab for refresh buttons" | Out-Null
+
+    Invoke-ButtonByNames -Root $MainWindow -Names @("RefreshProviderHealthButton", "Refresh Provider Health", "Provider Health") -Description "refresh provider health" | Out-Null
+
+    Invoke-ButtonByNames -Root $MainWindow -Names @("RefreshCacheStatsButton", "Refresh Cache Stats", "Cache Stats") -Description "refresh cache stats" | Out-Null
+
+
+
+    # Confirmable actions. By default verify presence only. With -ExerciseConfirmableActions, click and cancel/No.
+
+    $confirmableActions = @(
+
+        @{ Names = @("ClearExpiredCacheButton", "Clear Expired Cache", "Clear expired"); Description = "clear expired cache confirmation" },
+
+        @{ Names = @("VacuumCacheButton", "Vacuum Cache", "Vacuum"); Description = "vacuum cache confirmation" },
+
+        @{ Names = @("ClearAllCacheButton", "Clear All Cache", "Clear all"); Description = "clear all cache confirmation" },
+
+        @{ Names = @("RebuildKillmailDerivedIntelButton", "Rebuild Killmail Derived Intel", "Rebuild Derived Intel", "Derived Intel"); Description = "derived intel rebuild confirmation" }
+
+    )
+
+
+
+    foreach ($action in $confirmableActions) {
+
+        if ($ExerciseConfirmableActions) {
+
+            $beforeDialogs = @(Get-AppDialogWindows -Process $Process -MainWindow $MainWindow).Count
+
+            $clicked = Invoke-ButtonByNames -Root $MainWindow -Names $action.Names -Description $action.Description
+
+            if ($clicked) {
+
+                $dismissed = Dismiss-AppDialogs -Process $Process -MainWindow $MainWindow -PreferredButtons @("No", "Cancel", "OK", "Close")
+
+                if ($dismissed -lt 1) {
+
+                    Add-Warning "No dialog was detected after invoking $($action.Description). If this action is destructive without confirmation, add an app-level test hook before making this required."
+
+                }
+
+                else {
+
+                    Add-Pass "Invoked and dismissed confirmation path for $($action.Description)."
+
+                }
+
+            }
+
+        }
+
+        else {
+
+            Assert-ButtonPresent -Root $MainWindow -Names $action.Names -Description $action.Description | Out-Null
+
+        }
+
+    }
+
+
+
+    # Ensure no dialogs remain open after smoke.
+
+    $remaining = Dismiss-AppDialogs -Process $Process -MainWindow $MainWindow -PreferredButtons @("No", "Cancel", "OK", "Close")
+
+    if ($remaining -gt 0) {
+
+        Add-Warning "Dismissed $remaining leftover dialog(s) after UI smoke."
+
+    }
+
+
+
+    $Process.Refresh()
+
+    if ($Process.HasExited) {
+
+        Add-Failure "PMG exited during full UI smoke. ExitCode=$($Process.ExitCode)"
+
+    }
+
+    elseif (-not $Process.Responding) {
+
+        Add-Failure "PMG is not responding after full UI smoke."
+
+    }
+
+    else {
+
+        Add-Pass "Full UI Automation smoke completed with app still responsive."
+
+    }
+
+}
+
+
+
+
+function Find-ElementByAutomationId {
+    param(
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+        [Parameter(Mandatory)][string]$AutomationId
+    )
+
+    $condition = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::AutomationIdProperty,
+        $AutomationId
+    )
+
+    return $Root.FindFirst(
+        [System.Windows.Automation.TreeScope]::Descendants,
+        $condition
+    )
+}
+
+function Get-ElementNameByAutomationId {
+    param(
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+        [Parameter(Mandatory)][string]$AutomationId
+    )
+
+    $element = Find-ElementByAutomationId -Root $Root -AutomationId $AutomationId
+    if ($null -eq $element) {
+        return $null
+    }
+
+    try {
+        return [string]$element.Current.Name
+    }
+    catch {
+        return $null
+    }
+}
+
+function Get-VisibleCountFromBoardSummary {
+    param([AllowNull()][string]$SummaryText)
+
+    if ([string]::IsNullOrWhiteSpace($SummaryText)) {
+        return $null
+    }
+
+    if ($SummaryText -match 'Visible\s+(\d+)') {
+        return [int]$Matches[1]
+    }
+
+    return $null
+}
+
+function Test-BoardPopulationFromFixture {
+    param(
+        [Parameter(Mandatory)][System.Windows.Automation.AutomationElement]$Root,
+        [Parameter(Mandatory)][string]$FixturePath,
+        [Parameter(Mandatory)][int]$TimeoutSeconds
+    )
+
+    Write-Section "Board population fixture smoke"
+
+    if (-not (Test-Path -LiteralPath $FixturePath)) {
+        Add-Failure "Board population fixture was not found: $FixturePath"
+        return
+    }
+
+    $fixtureLines = @(Get-Content -LiteralPath $FixturePath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $expectedCount = $fixtureLines.Count
+    $fixtureText = Get-Content -LiteralPath $FixturePath -Raw
+
+    if ($expectedCount -le 0 -or [string]::IsNullOrWhiteSpace($fixtureText)) {
+        Add-Failure "Board population fixture is empty or unreadable: $FixturePath"
+        return
+    }
+
+    Add-Pass "Loaded board fixture with $expectedCount non-empty line(s): $FixturePath"
+
+    Select-TabByName -Root $Root -Names @("Grill") -Description "Grill tab before board population fixture smoke" | Out-Null
+    Start-Sleep -Milliseconds 500
+
+    $statusBefore = Get-ElementNameByAutomationId -Root $Root -AutomationId "BoardPopulationStatusText"
+    $summaryBefore = Get-ElementNameByAutomationId -Root $Root -AutomationId "BoardSummaryText"
+
+    Write-Host "Board status before fixture: $statusBefore"
+    Write-Host "Board summary before fixture: $summaryBefore"
+
+    try {
+        $sentinelText = "PMG_SMOKE_TEST_CLIPBOARD_RESET_$([Guid]::NewGuid().ToString('N'))"
+        Set-Clipboard -Value $sentinelText
+        Start-Sleep -Milliseconds 750
+        Set-Clipboard -Value $fixtureText
+        Start-Sleep -Milliseconds 750
+    }
+    catch {
+        Add-Failure "Failed to perform clipboard state-change sequence for board fixture text: $($_.Exception.Message)"
+        return
+    }
+
+    Add-Pass "Changed clipboard state, then copied board fixture text for PMG clipboard-triggered board population."
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $sawStatusChange = $false
+    $sawVisibleRows = $false
+    $lastStatus = $statusBefore
+    $lastSummary = $summaryBefore
+    $lastVisible = Get-VisibleCountFromBoardSummary -SummaryText $summaryBefore
+    $requiredCompleteStatus = "Board population complete"
+    $sawExpectedVisibleRows = $false
+
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+
+        $status = Get-ElementNameByAutomationId -Root $Root -AutomationId "BoardPopulationStatusText"
+        $summary = Get-ElementNameByAutomationId -Root $Root -AutomationId "BoardSummaryText"
+        $visible = Get-VisibleCountFromBoardSummary -SummaryText $summary
+        $statusNormalized = ""
+        if ($null -ne $status) {
+            $statusNormalized = $status.Trim()
+        }
+
+        if ($null -ne $status -and $status -ne $statusBefore) {
+            $sawStatusChange = $true
+        }
+
+        if ($null -ne $visible -and $visible -gt 0) {
+            $sawVisibleRows = $true
+        }
+
+        if ($null -ne $visible -and $visible -ge $expectedCount) {
+            $sawExpectedVisibleRows = $true
+        }
+
+        if ($status -ne $lastStatus -or $summary -ne $lastSummary) {
+            Write-Host "Board status: $status"
+            Write-Host "Board summary: $summary"
+        }
+
+        $lastStatus = $status
+        $lastSummary = $summary
+        $lastVisible = $visible
+
+        if ($sawExpectedVisibleRows -and $statusNormalized -eq $requiredCompleteStatus) {
+            Add-Pass "Board fixture population completed. Visible=$visible Summary='$summary' Status='$status'"
+            return
+        }
+
+        if ($statusNormalized -eq $requiredCompleteStatus -and -not $sawExpectedVisibleRows) {
+            Add-Failure "Board status reached '$requiredCompleteStatus' before visible row count reached $expectedCount. LastVisible=$lastVisible LastSummary='$lastSummary'"
+            return
+        }
+    }
+
+    Add-Failure "Timed out after $TimeoutSeconds seconds waiting for board fixture population to complete. RequiredStatus='$requiredCompleteStatus' SawStatusChange=$sawStatusChange SawVisibleRows=$sawVisibleRows SawExpectedVisibleRows=$sawExpectedVisibleRows LastVisible=$lastVisible LastStatus='$lastStatus' LastSummary='$lastSummary'"
+}
+
+function Test-PmgLaunch {
+
+    param([Parameter(Mandatory)][string]$ExePath)
+
+
+
+    Write-Section "Runtime launch/responsiveness smoke"
+
+
+
+    $proc = $null
+
+
+
+    try {
+
+        Write-Host "Launching: $ExePath"
+
+        $proc = Start-Process -FilePath $ExePath -WorkingDirectory (Split-Path -Parent $ExePath) -PassThru
+
+
+
+        $deadline = (Get-Date).AddSeconds(25)
+
+        $sawWindow = $false
+
+
+
+        while ((Get-Date) -lt $deadline) {
+
+            Start-Sleep -Milliseconds 500
+
+            $proc.Refresh()
+
+
+
+            if ($proc.HasExited) {
+
+                Add-Failure "PMG exited during startup. ExitCode=$($proc.ExitCode)"
+
+                return
+
+            }
+
+
+
+            if ($proc.MainWindowHandle -ne [IntPtr]::Zero) {
+
+                $sawWindow = $true
+
+                break
+
+            }
+
+        }
+
+
+
+        if (-not $sawWindow) {
+
+            Add-Failure "PMG process started but no main window handle appeared within 25 seconds."
+
+            return
+
+        }
+
+
+
+        Add-Pass "PMG main window handle appeared."
+
+
+
+        $sampleCount = [Math]::Max(1, [Math]::Ceiling($ResponsivenessSeconds / [Math]::Max(1, $SampleIntervalSeconds)))
+
+        $allResponsive = $true
+
+
+
+        for ($i = 1; $i -le $sampleCount; $i++) {
+
+            Start-Sleep -Seconds $SampleIntervalSeconds
+
+            $proc.Refresh()
+
+
+
+            if ($proc.HasExited) {
+
+                Add-Failure "PMG exited during responsiveness sampling. ExitCode=$($proc.ExitCode)"
+
+                return
+
+            }
+
+
+
+            $responding = $false
+
+
+
+            try {
+
+                $responding = [bool]$proc.Responding
+
+            }
+
+            catch {
+
+                Add-Warning "Could not read Process.Responding for sample ${i}: $($_.Exception.Message)"
+
+                $responding = $false
+
+            }
+
+
+
+            Write-Host ("Sample {0}/{1}: Responding={2}; WindowTitle='{3}'" -f $i, $sampleCount, $responding, $proc.MainWindowTitle)
+
+
+
+            if (-not $responding) {
+
+                $allResponsive = $false
+
+            }
+
+        }
+
+
+
+        if ($allResponsive) {
+
+            Add-Pass "PMG remained responsive for approximately $ResponsivenessSeconds seconds."
+
+        }
+
+        else {
+
+            Add-Failure "PMG reported non-responsive during at least one sample."
+
+        }
+
+
+
+        if ($FullUiSmoke -or $UiInventory) {
+
+            if (Initialize-UiAutomation) {
+
+                $mainAutomationWindow = Get-MainAutomationWindow -Process $proc -TimeoutSeconds 20
+
+                if ($null -eq $mainAutomationWindow) {
+
+                    Add-Failure "Could not resolve main AutomationElement for PMG window."
+
+                }
+
+                else {
+
+                    if ($FullUiSmoke) {
+
+                        Invoke-FullUiSmoke -Process $proc -MainWindow $mainAutomationWindow
+
+                    }
+
+                    elseif ($UiInventory) {
+
+                        Write-UiInventory -Root $mainAutomationWindow
+
+                    }
+
+                }
+
+            }
+
+        }
+
+
+
+        $proc.Refresh()
+
+
+
+        if ($proc.HasExited) {
+
+            Add-Pass "PMG exited before close request. ExitCode=$($proc.ExitCode)"
+
+            return
+
+        }
+
+
+
+        if ($KeepAppOpen) {
+
+            Add-Warning "Leaving PMG open because -KeepAppOpen was specified. Validation script will not close it."
+
+            return
+
+        }
+
+
+
+        Write-Host "Requesting normal close via CloseMainWindow()."
+
+        $closeRequested = $proc.CloseMainWindow()
+
+
+
+        if (-not $closeRequested) {
+
+            Add-Failure "CloseMainWindow() returned false."
+
+            return
+
+        }
+
+
+
+        $closed = $proc.WaitForExit(15000)
+
+
+
+        if (-not $closed) {
+
+            Add-Failure "PMG did not close within 15 seconds after CloseMainWindow()."
+
+            return
+
+        }
+
+
+
+        $proc.Refresh()
+
+        Add-Pass "PMG closed normally. ExitCode=$($proc.ExitCode)"
+
+    }
+
+    finally {
+
+        if ($null -ne $proc -and -not $KeepAppOpen) {
+
+            try {
+
+                $proc.Refresh()
+
+
+
+                if (-not $proc.HasExited) {
+
+                    Add-Warning "Killing leftover PMG validation process after failure."
+
+                    Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+
+                }
+
+            }
+
+            catch {
+
+                Add-Warning "Failed during cleanup of PMG process: $($_.Exception.Message)"
+
+            }
+
+        }
+
+    }
+
+}
+
+
+
+$RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+
+$artifactRoot = Join-Path $RepoRoot "artifacts\smoke-tests"
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+
+$runDir = Join-Path $artifactRoot $timestamp
+
+New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+
+
+
+$transcriptPath = Join-Path $runDir "pmg-smoke-test-transcript.txt"
+
+
+
+try {
+
+    Start-Transcript -Path $transcriptPath -Force | Out-Null
+
+}
+
+catch {
+
+    Write-Host "[WARN] Failed to start transcript: $($_.Exception.Message)" -ForegroundColor Yellow
+
+}
+
+
+
+try {
+
+    Write-Section "PMG smoke/regression validation"
+
+    Write-Host "Repo root: $RepoRoot"
+
+    Write-Host "Transcript: $transcriptPath"
+
+    Write-Host "FullUiSmoke: $FullUiSmoke"
+    $effectiveBoardFixturePath = $BoardFixturePath
+    if ([string]::IsNullOrWhiteSpace($effectiveBoardFixturePath)) {
+        $effectiveBoardFixturePath = Join-Path (Join-Path $RepoRoot "test-fixtures") "clipboard-large-local-list-valid.txt"
+    }
+    Write-Host "Board fixture path: $effectiveBoardFixturePath"
+    Write-Host "SkipBoardPopulationSmoke: $SkipBoardPopulationSmoke"
+
+    Write-Host "ExerciseConfirmableActions: $ExerciseConfirmableActions"
+
+
+
+    $appProject = Join-Path $RepoRoot "PitmastersGrill\PitmastersGrill.csproj"
+
+    $testProject = Join-Path $RepoRoot "PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"
+
+    $mainWindowCodeBehind = Join-Path $RepoRoot "PitmastersGrill\MainWindow.xaml.cs"
+
+    $mainWindowXaml = Join-Path $RepoRoot "PitmastersGrill\MainWindow.xaml"
+
+    $appExe = Join-Path $RepoRoot "PitmastersGrill\bin\Debug\net10.0-windows\PitmastersGrill.exe"
+
+
+
+    Assert-Path $appProject "App project"
+
+    Assert-Path $testProject "Test project"
+
+    Assert-Path $mainWindowCodeBehind "MainWindow code-behind"
+
+    Assert-Path $mainWindowXaml "MainWindow XAML"
+
+
+
+    Write-Section "Git state"
+
+
+
+    $branch = (& git -C $RepoRoot branch --show-current).Trim()
+
+    Write-Host "Branch: $branch"
+
+
+
+    $statusLines = @(& git -C $RepoRoot status --short)
+
+
+
+    if ($statusLines.Count -eq 0) {
+
+        Add-Pass "Working tree is clean."
+
+    }
+
+    else {
+
+        Write-Host "Working tree status:"
+
+        $statusLines | ForEach-Object { Write-Host $_ }
+
+
+
+        if ($RequireClean) {
+
+            Add-Failure "Working tree is not clean and -RequireClean was specified."
+
+        }
+
+        else {
+
+            Add-Warning "Working tree is not clean. Continuing because -RequireClean was not specified."
+
+        }
+
+    }
+
+
+
+    Write-Section "MainWindow line counts"
+
+
+
+    $codeBehindLines = Get-FileLineCount $mainWindowCodeBehind
+
+    $xamlLines = Get-FileLineCount $mainWindowXaml
+
+
+
+    Write-Host "MainWindow.xaml.cs: $codeBehindLines"
+
+    Write-Host "MainWindow.xaml:    $xamlLines"
+
+
+
+    if ($EnforceLineGate) {
+
+        if ($codeBehindLines -ge $MainWindowCodeBehindMaxLines) {
+
+            Add-Failure "MainWindow.xaml.cs line count $codeBehindLines is not under $MainWindowCodeBehindMaxLines."
+
+        }
+
+        else {
+
+            Add-Pass "MainWindow.xaml.cs is under $MainWindowCodeBehindMaxLines lines."
+
+        }
+
+
+
+        if ($xamlLines -ge $MainWindowXamlMaxLines) {
+
+            Add-Failure "MainWindow.xaml line count $xamlLines is not under $MainWindowXamlMaxLines."
+
+        }
+
+        else {
+
+            Add-Pass "MainWindow.xaml is under $MainWindowXamlMaxLines lines."
+
+        }
+
+    }
+
+    else {
+
+        if ($xamlLines -ge $MainWindowXamlMaxLines) {
+
+            Add-Warning "MainWindow.xaml is not under $MainWindowXamlMaxLines lines."
+
+        }
+
+        else {
+
+            Add-Pass "MainWindow.xaml is under $MainWindowXamlMaxLines lines."
+
+        }
+
+
+
+        if ($codeBehindLines -ge $MainWindowCodeBehindMaxLines) {
+
+            Add-Warning "MainWindow.xaml.cs is not under $MainWindowCodeBehindMaxLines lines yet. This is reported but not failed without -EnforceLineGate."
+
+        }
+
+        else {
+
+            Add-Pass "MainWindow.xaml.cs is under $MainWindowCodeBehindMaxLines lines."
+
+        }
+
+    }
+
+
+
+    if (-not $SkipDotNet) {
+
+        Write-Section "Build/test"
+
+        Invoke-NativeChecked -FilePath "dotnet" -Arguments @("test", $testProject) -Description "dotnet test" | Out-Null
+
+        Invoke-NativeChecked -FilePath "dotnet" -Arguments @("build", $appProject) -Description "dotnet build" | Out-Null
+
+    }
+
+    else {
+
+        Add-Warning "Skipping dotnet test/build because -SkipDotNet was specified."
+
+    }
+
+
+
+    if (-not $SkipDiffCheck) {
+
+        Write-Section "Diff whitespace check"
+
+        Invoke-NativeChecked -FilePath "git" -Arguments @("-C", $RepoRoot, "--no-pager", "diff", "--check") -Description "git diff --check" | Out-Null
+
+    }
+
+    else {
+
+        Add-Warning "Skipping git diff --check because -SkipDiffCheck was specified."
+
+    }
+
+
+
+    if (-not $SkipLaunch) {
+
+        Assert-Path $appExe "Built app executable"
+
+        Test-PmgLaunch -ExePath $appExe
+
+    }
+
+    else {
+
+        Add-Warning "Skipping WPF launch/responsiveness checks because -SkipLaunch was specified."
+
+    }
+
+
+
+    Show-RecentLogs
+
+
+
+    Write-Section "Summary"
+
+    Write-Host "Warnings: $($script:Warnings.Count)"
+
+    Write-Host "Failures: $($script:Failures.Count)"
+
+
+
+    if ($script:UiSmokeFindings.Count -gt 0) {
+
+        Write-Host ""
+
+        Write-Host "UI smoke findings:"
+
+        $script:UiSmokeFindings | ForEach-Object { Write-Host "- $_" }
+
+    }
+
+
+
+    if ($script:Warnings.Count -gt 0) {
+
+        Write-Host ""
+
+        Write-Host "Warnings:"
+
+        $script:Warnings | ForEach-Object { Write-Host "- $_" -ForegroundColor Yellow }
+
+    }
+
+
+
+    if ($script:Failures.Count -gt 0) {
+
+        Write-Host ""
+
+        Write-Host "Failures:"
+
+        $script:Failures | ForEach-Object { Write-Host "- $_" -ForegroundColor Red }
+
+        Write-Host ""
+
+        Write-Host "Transcript: $transcriptPath"
+
+        exit 1
+
+    }
+
+
+
+    Add-Pass "PMG smoke/regression validation completed successfully."
+
+    Write-Host "Transcript: $transcriptPath"
+
+    exit 0
+
+}
+
+catch {
+
+    Add-Failure "Unhandled validation exception: $($_.Exception.Message)"
+
+    Show-RecentLogs
+
+    Write-Host ""
+
+    Write-Host "Transcript: $transcriptPath"
+
+    exit 1
+
+}
+
+finally {
+
+    try {
+
+        Stop-Transcript | Out-Null
+
+    }
+
+    catch {
+
+        # Ignore transcript stop failures.
+
+    }
+
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,262 @@
+# PMG local smoke/regression validation
+
+
+
+`Invoke-PmgSmokeTest.ps1` is a local validation script for Pitmasters Grill development and release-prep work.
+
+
+
+It exists because build/test/diff checks are necessary but not sufficient for PMG. During the v1.4.0 MainWindow refactor, runtime-only issues were caught by manual smoke testing:
+
+
+
+- a `StaticResourceExtension` startup failure after extracting a UserControl
+
+- a render-then-stall failure after extracting settings coordination
+
+
+
+This script automates the parts of that manual workflow that are practical to automate.
+
+
+
+## Quick run
+
+
+
+From the repository root:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1
+
+```
+
+
+
+Shorter responsiveness sample:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -ResponsivenessSeconds 30
+
+```
+
+
+
+## Full UI smoke
+
+
+
+Run deeper UI Automation checks:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30
+
+```
+
+
+
+The full UI smoke attempts to:
+
+
+
+- navigate major tabs
+
+- navigate Intel nested tabs
+
+- toggle reversible settings and restore them
+
+- adjust window opacity and restore it
+
+- run safe diagnostics refresh buttons
+
+- verify confirmable maintenance buttons are present
+
+- keep PMG responsive and close normally
+
+
+
+To also click confirmation-based maintenance buttons and cancel/No the dialog:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ExerciseConfirmableActions
+
+```
+
+
+
+Use `-ExerciseConfirmableActions` only when you are comfortable with the script clicking those buttons. The script attempts to cancel/No resulting dialogs and warns if no dialog appears.
+
+
+
+## Helpful options
+
+
+
+Require a clean working tree:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -RequireClean
+
+```
+
+
+
+Enforce the current MainWindow line-count gate:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -EnforceLineGate
+
+```
+
+
+
+Write an inventory of discoverable UI Automation elements:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -UiInventory -SkipDotNet -ResponsivenessSeconds 5
+
+```
+
+
+
+Leave the app open after validation:
+
+
+
+```powershell
+
+.\scripts\Invoke-PmgSmokeTest.ps1 -KeepAppOpen
+
+```
+
+
+
+## What it checks
+
+
+
+The script currently checks:
+
+
+
+- current Git branch
+
+- working tree status
+
+- `MainWindow.xaml.cs` and `MainWindow.xaml` line counts
+
+- explicit `dotnet test` path
+
+- explicit `dotnet build` path
+
+- `git --no-pager diff --check`
+
+- WPF process launch from the built executable
+
+- main window handle creation
+
+- responsiveness samples over a configurable interval
+
+- normal close via `CloseMainWindow()`
+
+- optional UI Automation navigation/action checks
+
+- recent PMG log discovery and tail capture on failure
+
+
+
+Validation transcripts are written under:
+
+
+
+```text
+
+artifacts/smoke-tests/<timestamp>/pmg-smoke-test-transcript.txt
+
+```
+
+
+
+## What remains manual or needs future app hooks
+
+
+
+This script is intended to reduce manual validation drift, but some checks may still require manual validation or future test hooks:
+
+
+
+- visual polish, spacing, wrapping, and readability
+
+- real external ESI/zKill/R2Z2 success paths
+
+- destructive maintenance actions without a guaranteed confirmation/test mode
+
+- OS File Explorer/dialog behavior
+
+- exact user-facing visual comparison after large XAML refactors
+
+
+
+## Future improvement
+
+
+
+If UI Automation cannot consistently find controls by visible text, add stable `AutomationProperties.AutomationId` values to important PMG controls and update this script to prefer those IDs.
+
+
+
+Root-level `dotnet test` and `dotnet build` are intentionally not used because this repository does not have a root solution/project file. The script uses explicit project paths instead.
+## UI Automation selectors
+
+The full UI smoke path prefers stable `AutomationProperties.AutomationId` selectors. Named WPF controls should keep their automation IDs aligned with their `x:Name` values so the script can find controls by intent instead of fragile screen coordinates or visible text.
+
+When adding new buttons/settings that should be part of release validation, give the control a stable `x:Name` and keep the smoke script selector list updated.
+
+## Board population fixture smoke
+
+The full UI smoke can also populate the board from the checked-in large local-list fixture:
+
+```text
+test-fixtures/clipboard-large-local-list-valid.txt
+```
+
+This fixture is expected to contain 100 pilot names. The smoke script changes the clipboard to a unique sentinel value, then copies the fixture text to the clipboard while PMG is running, waits for `BoardPopulationStatusText` to reach `Board population complete` and requires the board summary to show at least the fixture line count.
+
+Run:
+
+```powershell
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke
+```
+
+Skip only the board fixture portion:
+
+```powershell
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke
+```
+
+Adjust the timeout for slower systems or cold caches:
+
+```powershell
+.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -BoardPopulationTimeoutSeconds 300
+```


### PR DESCRIPTION
﻿## Summary
- Adds a local PMG smoke/regression validation script.
- Adds Windows UI Automation coverage for startup, responsiveness, tab navigation, reversible settings toggles, diagnostics refresh actions, and confirmable maintenance button presence.
- Adds board population smoke coverage using the checked-in 100-name clipboard fixture.
- Adds stable AutomationProperties.AutomationId values to PMG controls used by the smoke script.
- Ignores generated local smoke-test transcripts under artifacts/smoke-tests/.

## Why
Build/test/diff checks were not enough to catch recent runtime regressions during the v1.4.0 MainWindow refactor.

This gives PMG a repeatable local validation path that reduces manual smoke-test drift before PRs and releases.

## Validation
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30 -BoardPopulationTimeoutSeconds 300
  - Passed.
  - Board fixture loaded 100 names.
  - Board status advanced from Board population in progress to Board population complete.
  - App stayed responsive and closed normally.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke -ResponsivenessSeconds 30
  - Passed.
- dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"
  - Passed, 157/157.
- dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"
  - Passed.
- git --no-pager diff --check
  - Clean.

## Notes
- ExerciseConfirmableActions is available but should remain non-gating/optional for now because destructive-action dialog behavior needs stronger app-level test hooks before being treated as required.
- MainWindow.xaml.cs remains above 2,000 lines; issue #54 remains open for continued refactor work.

Closes #65
