### PR TITLE
Continue MainWindow responsibility extraction

### DIFF
--- a/PitmastersGrill.Tests/Services/AnalysisTabPresenterTests.cs
+++ b/PitmastersGrill.Tests/Services/AnalysisTabPresenterTests.cs
@@ -1,0 +1,195 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Navigation;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class AnalysisTabPresenterTests
+    {
+        [Fact]
+        public void UpdateBoardSummary_SetsExpectedBannerText()
+        {
+            RunOnStaThread(() =>
+            {
+                var controls = CreateControls();
+                var presenter = CreatePresenter(controls);
+                var rows = new List<PilotBoardRow>
+                {
+                    new() { CharacterName = "Scout One", IsWatched = true, BoardSignalKind = "ConfirmedNormal" },
+                    new() { CharacterName = "Scout Two", HasDerivedBaitEvidence = true, BoardSignalKind = "ConfirmedCovert" }
+                };
+
+                presenter.UpdateBoardSummary(rows);
+
+                Assert.Equal("Visible 2 | Watched 1 | Bait 1 | Hard Cyno 1 | Covert Cyno 1", controls.BoardSummaryText.Text);
+            });
+        }
+
+        [Fact]
+        public void UpdateAnalysisTab_WithNoRows_ShowsEmptyState()
+        {
+            RunOnStaThread(() =>
+            {
+                var controls = CreateControls();
+                var presenter = CreatePresenter(controls);
+
+                presenter.UpdateAnalysisTab(new List<PilotBoardRow>());
+
+                Assert.Equal(Visibility.Visible, controls.AnalysisEmptyStateText.Visibility);
+                Assert.Equal(Visibility.Collapsed, controls.AnalysisDetailsPanel.Visibility);
+                Assert.Equal("No visible pilots yet. Load or refresh the Grill to see aggregate analysis.", controls.AnalysisEmptyStateText.Text);
+            });
+        }
+
+        [Fact]
+        public void UpdateAnalysisTab_WithRows_PopulatesTextsListsAndHyperlinks()
+        {
+            RunOnStaThread(() =>
+            {
+                var controls = CreateControls();
+                var presenter = CreatePresenter(controls);
+                var rows = new List<PilotBoardRow>
+                {
+                    new()
+                    {
+                        CharacterName = "Alice",
+                        CharacterId = "9001",
+                        AllianceName = "Alliance A",
+                        AllianceId = "3001",
+                        CorpName = "Corp One",
+                        CorpId = "2001",
+                        IsWatched = true,
+                        BoardSignalKind = "ConfirmedNormal",
+                        KillCount = 5,
+                        LossCount = 0
+                    },
+                    new()
+                    {
+                        CharacterName = "Bob",
+                        CharacterId = "",
+                        AllianceName = "Alliance A",
+                        CorpName = "Corp One",
+                        HasDerivedBaitEvidence = true,
+                        BoardSignalKind = "ConfirmedCovert",
+                        KillCount = 1,
+                        LossCount = 1
+                    },
+                    new()
+                    {
+                        CharacterName = "Cara",
+                        CharacterId = "9003",
+                        AllianceName = "Alliance B",
+                        AllianceId = "3002",
+                        CorpName = "Corp Two",
+                        CorpId = "2002",
+                        BaitOverride = true
+                    }
+                };
+
+                presenter.UpdateAnalysisTab(rows);
+
+                Assert.Equal(Visibility.Collapsed, controls.AnalysisEmptyStateText.Visibility);
+                Assert.Equal(Visibility.Visible, controls.AnalysisDetailsPanel.Visibility);
+                Assert.Equal("Visible pilots: 3 | Watched pilots: 1 | Confirmed cynos: Hard 1 | Covert 1 | Bait 2", controls.AnalysisVisibleCountsText.Text);
+                Assert.Equal("Unique corps: 2 | Unique alliances: 2", controls.AnalysisUniqueCountsText.Text);
+                Assert.Equal(2, controls.AnalysisAllianceItems.Count);
+                Assert.Equal(2, controls.AnalysisCorpItems.Count);
+                Assert.Equal(string.Empty, controls.AnalysisSignalsText.Text);
+
+                var allianceLink = controls.AnalysisAllianceTopText.Inlines.OfType<Hyperlink>().FirstOrDefault();
+                Assert.NotNull(allianceLink);
+                Assert.Equal("https://zkillboard.com/alliance/3001/", allianceLink!.NavigateUri?.AbsoluteUri);
+
+                var highlightLink = controls.AnalysisHighlightsText.Inlines.OfType<Hyperlink>().FirstOrDefault();
+                Assert.NotNull(highlightLink);
+                Assert.Equal("https://zkillboard.com/character/9001/", highlightLink!.NavigateUri?.AbsoluteUri);
+                Assert.Equal("Top alliances: ", ((Run)controls.AnalysisAllianceTopText.Inlines.FirstInline!).Text);
+                Assert.Equal("Highlights: ", ((Run)controls.AnalysisHighlightsText.Inlines.FirstInline!).Text);
+            });
+        }
+
+        private static AnalysisTabPresenter CreatePresenter(AnalysisPresenterControls controls)
+        {
+            return new AnalysisTabPresenter(
+                new AnalysisTabController(),
+                new ZkillUrlBuilder(),
+                (_, _) => { },
+                controls.BoardSummaryText,
+                controls.AnalysisEmptyStateText,
+                controls.AnalysisDetailsPanel,
+                controls.AnalysisVisibleCountsText,
+                controls.AnalysisUniqueCountsText,
+                controls.AnalysisAllianceTopText,
+                controls.AnalysisCorpTopText,
+                controls.AnalysisSignalsText,
+                controls.AnalysisHighlightsText,
+                controls.AnalysisAllianceItems,
+                controls.AnalysisCorpItems);
+        }
+
+        private static AnalysisPresenterControls CreateControls()
+        {
+            return new AnalysisPresenterControls(
+                new TextBlock(),
+                new TextBlock(),
+                new StackPanel(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new ObservableCollection<AnalysisAffiliationListItem>(),
+                new ObservableCollection<AnalysisAffiliationListItem>());
+        }
+
+        private sealed record AnalysisPresenterControls(
+            TextBlock BoardSummaryText,
+            TextBlock AnalysisEmptyStateText,
+            StackPanel AnalysisDetailsPanel,
+            TextBlock AnalysisVisibleCountsText,
+            TextBlock AnalysisUniqueCountsText,
+            TextBlock AnalysisAllianceTopText,
+            TextBlock AnalysisCorpTopText,
+            TextBlock AnalysisSignalsText,
+            TextBlock AnalysisHighlightsText,
+            ObservableCollection<AnalysisAffiliationListItem> AnalysisAllianceItems,
+            ObservableCollection<AnalysisAffiliationListItem> AnalysisCorpItems);
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? capturedException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+            {
+                ExceptionDispatchInfo.Capture(capturedException).Throw();
+            }
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/BoardColumnLayoutPersistenceControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/BoardColumnLayoutPersistenceControllerTests.cs
@@ -1,0 +1,181 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class BoardColumnLayoutPersistenceControllerTests
+    {
+        [Fact]
+        public void ApplySavedBoardColumnLayout_WhenInvalid_ClearsSettingsSavesAndFallsBackToCanonical()
+        {
+            RunOnStaThread(() =>
+            {
+                var saves = new List<AppSettings>();
+                var appliedReasons = new List<string>();
+                var canonicalReasons = new List<string>();
+                var (layoutController, _) = CreateInitializedLayoutController();
+                var controller = new BoardColumnLayoutPersistenceController(layoutController, saves.Add);
+                var settings = new AppSettings
+                {
+                    BoardColumnLayout = new List<BoardColumnLayoutSetting>
+                    {
+                        new() { ColumnKey = "SigColumn", DisplayIndex = 0, WidthValue = 1, WidthUnitType = "Pixel" }
+                    }
+                };
+
+                controller.ApplySavedBoardColumnLayout(
+                    settings,
+                    (_, reason) => appliedReasons.Add(reason),
+                    canonicalReasons.Add);
+
+                Assert.Empty(settings.BoardColumnLayout);
+                Assert.Single(saves);
+                Assert.Empty(appliedReasons);
+                Assert.Equal("Discard invalid saved board layout", canonicalReasons[0]);
+            });
+        }
+
+        [Fact]
+        public void TryQueueBoardColumnLayoutSave_WhenReady_CapturesReason()
+        {
+            RunOnStaThread(() =>
+            {
+                var (layoutController, _) = CreateInitializedLayoutController();
+                var controller = new BoardColumnLayoutPersistenceController(layoutController, _ => { });
+
+                controller.MarkBoardColumnLayoutReady();
+                var queued = controller.TryQueueBoardColumnLayoutSave(
+                    isApplyingSettings: false,
+                    isBoardLayoutHostReady: () => true,
+                    reason: "Column width changed");
+
+                Assert.True(queued);
+                Assert.Equal("Column width changed", controller.DequeuePendingBoardColumnLayoutSaveReason());
+            });
+        }
+
+        [Fact]
+        public void SaveCurrentBoardColumnLayout_WhenLayoutChanged_SavesSanitizedLayout()
+        {
+            RunOnStaThread(() =>
+            {
+                var saves = new List<AppSettings>();
+                var (layoutController, columns) = CreateInitializedLayoutController();
+                var controller = new BoardColumnLayoutPersistenceController(layoutController, saves.Add);
+                var settings = new AppSettings();
+
+                columns["SigColumn"].Width = new DataGridLength(60, DataGridLengthUnitType.Pixel);
+                columns["CharacterColumn"].Width = new DataGridLength(140, DataGridLengthUnitType.Pixel);
+                controller.MarkBoardColumnLayoutReady();
+                controller.SaveCurrentBoardColumnLayout(settings, () => true, "Test save");
+
+                Assert.Single(saves);
+                Assert.NotEmpty(settings.BoardColumnLayout);
+                Assert.Contains(settings.BoardColumnLayout, entry => entry.ColumnKey == "SigColumn" && entry.WidthValue >= 60d);
+            });
+        }
+
+        [Fact]
+        public void FitVisibleBoardColumnsToWidth_WhenWidthIsTight_ShrinksColumnsAboveMinimum()
+        {
+            RunOnStaThread(() =>
+            {
+                var (layoutController, columns) = CreateInitializedLayoutController();
+                var controller = new BoardColumnLayoutPersistenceController(layoutController, _ => { });
+
+                columns["SigColumn"].Width = new DataGridLength(80, DataGridLengthUnitType.Pixel);
+                columns["CharacterColumn"].Width = new DataGridLength(200, DataGridLengthUnitType.Pixel);
+                columns["AllianceColumn"].Width = new DataGridLength(180, DataGridLengthUnitType.Pixel);
+                columns["CorpColumn"].Visibility = Visibility.Collapsed;
+                columns["KillsColumn"].Visibility = Visibility.Collapsed;
+                columns["LossesColumn"].Visibility = Visibility.Collapsed;
+                columns["AvgFleetSizeColumn"].Visibility = Visibility.Collapsed;
+                columns["LastShipSeenColumn"].Visibility = Visibility.Collapsed;
+                columns["LastSeenColumn"].Visibility = Visibility.Collapsed;
+                columns["CynoHullSeenColumn"].Visibility = Visibility.Collapsed;
+
+                controller.FitVisibleBoardColumnsToWidth(220d);
+
+                var visibleColumns = new[]
+                {
+                    columns["SigColumn"],
+                    columns["CharacterColumn"],
+                    columns["AllianceColumn"]
+                };
+
+                var totalWidth = visibleColumns.Sum(column => column.Width.DisplayValue);
+                Assert.True(totalWidth <= 221d);
+                Assert.True(columns["SigColumn"].Width.DisplayValue >= layoutController.GetBoardColumnMinimumWidth("SigColumn"));
+                Assert.True(columns["CharacterColumn"].Width.DisplayValue >= layoutController.GetBoardColumnMinimumWidth("CharacterColumn"));
+                Assert.True(columns["AllianceColumn"].Width.DisplayValue >= layoutController.GetBoardColumnMinimumWidth("AllianceColumn"));
+            });
+        }
+
+        private static (BoardColumnLayoutController Controller, Dictionary<string, DataGridColumn> Columns) CreateInitializedLayoutController()
+        {
+            var columns = new Dictionary<string, DataGridColumn>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SigColumn"] = new DataGridTextColumn { Width = new DataGridLength(42, DataGridLengthUnitType.Pixel), DisplayIndex = 0 },
+                ["CharacterColumn"] = new DataGridTextColumn { Width = new DataGridLength(120, DataGridLengthUnitType.Pixel), DisplayIndex = 1 },
+                ["AllianceColumn"] = new DataGridTextColumn { Width = new DataGridLength(120, DataGridLengthUnitType.Pixel), DisplayIndex = 2 },
+                ["CorpColumn"] = new DataGridTextColumn { Width = new DataGridLength(140, DataGridLengthUnitType.Pixel), DisplayIndex = 3 },
+                ["KillsColumn"] = new DataGridTextColumn { Width = new DataGridLength(55, DataGridLengthUnitType.Pixel), DisplayIndex = 4 },
+                ["LossesColumn"] = new DataGridTextColumn { Width = new DataGridLength(55, DataGridLengthUnitType.Pixel), DisplayIndex = 5 },
+                ["AvgFleetSizeColumn"] = new DataGridTextColumn { Width = new DataGridLength(70, DataGridLengthUnitType.Pixel), DisplayIndex = 6 },
+                ["LastShipSeenColumn"] = new DataGridTextColumn { Width = new DataGridLength(100, DataGridLengthUnitType.Pixel), DisplayIndex = 7 },
+                ["LastSeenColumn"] = new DataGridTextColumn { Width = new DataGridLength(90, DataGridLengthUnitType.Pixel), DisplayIndex = 8 },
+                ["CynoHullSeenColumn"] = new DataGridTextColumn { Width = new DataGridLength(110, DataGridLengthUnitType.Pixel), DisplayIndex = 9 }
+            };
+
+            var controller = new BoardColumnLayoutController();
+            controller.InitializeColumns(
+                ("SigColumn", columns["SigColumn"]),
+                ("CharacterColumn", columns["CharacterColumn"]),
+                ("AllianceColumn", columns["AllianceColumn"]),
+                ("CorpColumn", columns["CorpColumn"]),
+                ("KillsColumn", columns["KillsColumn"]),
+                ("LossesColumn", columns["LossesColumn"]),
+                ("AvgFleetSizeColumn", columns["AvgFleetSizeColumn"]),
+                ("LastShipSeenColumn", columns["LastShipSeenColumn"]),
+                ("LastSeenColumn", columns["LastSeenColumn"]),
+                ("CynoHullSeenColumn", columns["CynoHullSeenColumn"]));
+            controller.ApplyColumnMinimumWidths();
+            controller.BuildCanonicalBoardColumnLayout();
+            return (controller, columns);
+        }
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? capturedException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+            {
+                ExceptionDispatchInfo.Capture(capturedException).Throw();
+            }
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/BoardColumnSettingsControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/BoardColumnSettingsControllerTests.cs
@@ -1,0 +1,233 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Controls;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class BoardColumnSettingsControllerTests
+    {
+        [Fact]
+        public void HandleBoardColumnVisibilityChanged_WhenNotApplying_UpdatesSettingsAppliesVisibilityAndSaves()
+        {
+            RunOnStaThread(() =>
+            {
+                var saves = new List<AppSettings>();
+                var applyCalls = 0;
+                var controller = CreateController(saves.Add);
+                var settings = new AppSettings();
+
+                controller.HandleBoardColumnVisibilityChanged(
+                    isApplyingSettings: false,
+                    settings,
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    () => applyCalls++);
+
+                Assert.False(settings.ShowSigColumn);
+                Assert.True(settings.ShowAllianceColumn);
+                Assert.False(settings.ShowCorpColumn);
+                Assert.True(settings.ShowKillsColumn);
+                Assert.False(settings.ShowLossesColumn);
+                Assert.True(settings.ShowAvgFleetSizeColumn);
+                Assert.False(settings.ShowLastShipSeenColumn);
+                Assert.True(settings.ShowLastSeenColumn);
+                Assert.False(settings.ShowCynoHullSeenColumn);
+                Assert.Equal(1, applyCalls);
+                Assert.Single(saves);
+            });
+        }
+
+        [Fact]
+        public void HandleBoardColumnVisibilityChanged_WhenApplying_DoesNothing()
+        {
+            RunOnStaThread(() =>
+            {
+                var saves = new List<AppSettings>();
+                var applyCalls = 0;
+                var controller = CreateController(saves.Add);
+                var settings = new AppSettings
+                {
+                    ShowSigColumn = true,
+                    ShowAllianceColumn = false
+                };
+
+                controller.HandleBoardColumnVisibilityChanged(
+                    isApplyingSettings: true,
+                    settings,
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    new CheckBox { IsChecked = true },
+                    new CheckBox { IsChecked = false },
+                    () => applyCalls++);
+
+                Assert.True(settings.ShowSigColumn);
+                Assert.False(settings.ShowAllianceColumn);
+                Assert.Equal(0, applyCalls);
+                Assert.Empty(saves);
+            });
+        }
+
+        [Fact]
+        public void HandleShowAllBoardColumns_SetsAllOptionalColumnsVisibleAndSaves()
+        {
+            var saves = new List<AppSettings>();
+            var applyCheckBoxesCalls = 0;
+            var applyVisibilityCalls = 0;
+            var controller = CreateController(saves.Add);
+            var settings = new AppSettings
+            {
+                ShowSigColumn = false,
+                ShowAllianceColumn = false,
+                ShowCorpColumn = false,
+                ShowKillsColumn = false,
+                ShowLossesColumn = false,
+                ShowAvgFleetSizeColumn = false,
+                ShowLastShipSeenColumn = false,
+                ShowLastSeenColumn = false,
+                ShowCynoHullSeenColumn = false
+            };
+
+            controller.HandleShowAllBoardColumns(
+                settings,
+                () => applyCheckBoxesCalls++,
+                () => applyVisibilityCalls++);
+
+            Assert.True(settings.ShowSigColumn);
+            Assert.True(settings.ShowAllianceColumn);
+            Assert.True(settings.ShowCorpColumn);
+            Assert.True(settings.ShowKillsColumn);
+            Assert.True(settings.ShowLossesColumn);
+            Assert.True(settings.ShowAvgFleetSizeColumn);
+            Assert.True(settings.ShowLastShipSeenColumn);
+            Assert.True(settings.ShowLastSeenColumn);
+            Assert.True(settings.ShowCynoHullSeenColumn);
+            Assert.Equal(1, applyCheckBoxesCalls);
+            Assert.Equal(1, applyVisibilityCalls);
+            Assert.Single(saves);
+        }
+
+        [Fact]
+        public void InitializeBoardColumnLayoutUi_InitializesLayoutAndAppliesCanonicalDefaults()
+        {
+            RunOnStaThread(() =>
+            {
+                var controller = CreateController(_ => { });
+                var appliedLayouts = new List<IReadOnlyList<BoardColumnLayoutSetting>>();
+                var reasons = new List<string>();
+
+                controller.InitializeBoardColumnLayoutUi(
+                    (layout, reason) =>
+                    {
+                        appliedLayouts.Add(new List<BoardColumnLayoutSetting>(layout));
+                        reasons.Add(reason);
+                    },
+                    ("SigColumn", new DataGridTextColumn()),
+                    ("CharacterColumn", new DataGridTextColumn()),
+                    ("AllianceColumn", new DataGridTextColumn()),
+                    ("CorpColumn", new DataGridTextColumn()),
+                    ("KillsColumn", new DataGridTextColumn()),
+                    ("LossesColumn", new DataGridTextColumn()),
+                    ("AvgFleetSizeColumn", new DataGridTextColumn()),
+                    ("LastShipSeenColumn", new DataGridTextColumn()),
+                    ("LastSeenColumn", new DataGridTextColumn()),
+                    ("CynoHullSeenColumn", new DataGridTextColumn()));
+
+                Assert.Single(appliedLayouts);
+                Assert.Equal("Apply canonical default board layout", reasons[0]);
+                Assert.Equal(10, appliedLayouts[0].Count);
+                Assert.Equal("SigColumn", appliedLayouts[0][0].ColumnKey);
+            });
+        }
+
+        [Fact]
+        public void HandleResetBoardLayout_ClearsSavedLayoutAndInvokesCallbacks()
+        {
+            var canonicalReasons = new List<string>();
+            var saveReasons = new List<string>();
+            var controller = CreateController(_ => { });
+            var settings = new AppSettings
+            {
+                BoardColumnLayout = new List<BoardColumnLayoutSetting>
+                {
+                    new() { ColumnKey = "SigColumn", DisplayIndex = 0, WidthValue = 42, WidthUnitType = "Pixel" }
+                }
+            };
+
+            controller.HandleResetBoardLayout(
+                settings,
+                canonicalReasons.Add,
+                saveReasons.Add);
+
+            Assert.Empty(settings.BoardColumnLayout);
+            Assert.Equal("Reset board layout to canonical defaults", canonicalReasons[0]);
+            Assert.Equal("Reset layout", saveReasons[0]);
+        }
+
+        [Fact]
+        public void HandleShowCorpAllianceCountsChanged_WhenNotApplying_UpdatesSettingRecomputesAndSaves()
+        {
+            var saves = new List<AppSettings>();
+            var recomputeCalls = 0;
+            var controller = CreateController(saves.Add);
+            var settings = new AppSettings();
+
+            controller.HandleShowCorpAllianceCountsChanged(
+                isApplyingSettings: false,
+                settings,
+                enabled: true,
+                recomputeCorpAllianceCounts: () => recomputeCalls++);
+
+            Assert.True(settings.ShowCorpAllianceCounts);
+            Assert.Equal(1, recomputeCalls);
+            Assert.Single(saves);
+        }
+
+        private static BoardColumnSettingsController CreateController(Action<AppSettings> saveSettings)
+        {
+            return new BoardColumnSettingsController(new BoardColumnLayoutController(), saveSettings);
+        }
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? capturedException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+            {
+                ExceptionDispatchInfo.Capture(capturedException).Throw();
+            }
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -12,7 +12,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -66,6 +65,7 @@ namespace PitmastersGrill
         private readonly BoardColumnLayoutPersistenceController _boardColumnLayoutPersistenceController;
         private readonly SettingsTabController _settingsTabController;
         private readonly AnalysisTabController _analysisTabController;
+        private readonly AnalysisTabPresenter _analysisTabPresenter = null!;
         private readonly WindowLayoutController _windowLayoutController;
         private readonly BoardPopulationStatusController _boardPopulationStatusController;
         private readonly BoardPopulationRowProcessor _boardPopulationRowProcessor;
@@ -257,6 +257,21 @@ namespace PitmastersGrill
             _ignoreAllianceBoardController = composed.IgnoreAllianceBoardController;
             _zkillUrlBuilder = composed.ZkillUrlBuilder;
             _browserLauncher = composed.BrowserLauncher;
+            _analysisTabPresenter = new AnalysisTabPresenter(
+                _analysisTabController,
+                _zkillUrlBuilder,
+                AnalysisHyperlink_RequestNavigate,
+                BoardSummaryText,
+                AnalysisEmptyStateText,
+                AnalysisDetailsPanel,
+                AnalysisVisibleCountsText,
+                AnalysisUniqueCountsText,
+                AnalysisAllianceTopText,
+                AnalysisCorpTopText,
+                AnalysisSignalsText,
+                AnalysisHighlightsText,
+                _analysisAllianceItems,
+                _analysisCorpItems);
             _eveSessionContextService = new EveSessionContextService();
 
             _ignoreAllianceListView = IgnoreAllianceListViewControl;
@@ -3191,12 +3206,7 @@ namespace PitmastersGrill
 
         private void UpdateBoardSummaryBanner()
         {
-            if (BoardSummaryText == null)
-            {
-                return;
-            }
-
-            BoardSummaryText.Text = BoardSummaryTextBuilder.Build(_currentRows);
+            _analysisTabPresenter.UpdateBoardSummary(_currentRows);
         }
 
         private void CurrentRows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -3240,52 +3250,7 @@ namespace PitmastersGrill
 
         private void UpdateAnalysisTab()
         {
-            if (AnalysisEmptyStateText == null ||
-                AnalysisDetailsPanel == null ||
-                AnalysisVisibleCountsText == null ||
-                AnalysisUniqueCountsText == null ||
-                AnalysisAllianceTopText == null ||
-                AnalysisCorpTopText == null ||
-                AnalysisSignalsText == null ||
-                AnalysisHighlightsText == null)
-            {
-                return;
-            }
-
-            var summary = _analysisTabController.BuildSummary(_currentRows);
-            if (!summary.HasVisibleRows)
-            {
-                AnalysisEmptyStateText.Visibility = Visibility.Visible;
-                AnalysisDetailsPanel.Visibility = Visibility.Collapsed;
-                AnalysisEmptyStateText.Text = summary.EmptyStateText;
-                return;
-            }
-
-            AnalysisEmptyStateText.Visibility = Visibility.Collapsed;
-            AnalysisDetailsPanel.Visibility = Visibility.Visible;
-            AnalysisVisibleCountsText.Text = summary.VisibleCountsText;
-            AnalysisUniqueCountsText.Text = summary.UniqueCountsText;
-            PopulateAnalysisAllianceTopText(summary.TopAlliances);
-            PopulateAnalysisCorpTopText(summary.TopCorps);
-            PopulateAnalysisAffiliationList(
-                _analysisAllianceItems,
-                _analysisTabController.BuildAffiliationListItems(summary.AllAlliances, "alliance"));
-            PopulateAnalysisAffiliationList(
-                _analysisCorpItems,
-                _analysisTabController.BuildAffiliationListItems(summary.AllCorps, "corporation"));
-            AnalysisSignalsText.Text = string.Empty;
-            PopulateAnalysisHighlightsText(summary.Highlights);
-        }
-
-        private static void PopulateAnalysisAffiliationList(
-            ObservableCollection<AnalysisAffiliationListItem> target,
-            IReadOnlyList<AnalysisAffiliationListItem> items)
-        {
-            target.Clear();
-            foreach (var item in items)
-            {
-                target.Add(item);
-            }
+            _analysisTabPresenter.UpdateAnalysisTab(_currentRows);
         }
 
         private bool IsSessionContextStale()
@@ -3411,165 +3376,6 @@ namespace PitmastersGrill
                 : "Unable to infer EVE context";
         }
 
-        private void PopulateAnalysisAllianceTopText(IReadOnlyList<AnalysisAffiliationSummary> alliances)
-        {
-            AnalysisAllianceTopText.Inlines.Clear();
-            AnalysisAllianceTopText.Inlines.Add(new Run("Top alliances: "));
-
-            if (alliances.Count == 0)
-            {
-                AnalysisAllianceTopText.Inlines.Add(new Run("none visible"));
-                return;
-            }
-
-            for (var index = 0; index < alliances.Count; index++)
-            {
-                if (index > 0)
-                {
-                    AnalysisAllianceTopText.Inlines.Add(new Run(" | "));
-                }
-
-                var alliance = alliances[index];
-                if (!string.IsNullOrWhiteSpace(alliance.Id) &&
-                    long.TryParse(alliance.Id, out _))
-                {
-                    AddHyperlinkInline(
-                        AnalysisAllianceTopText,
-                        alliance.Name,
-                        BuildAllianceZkillUrl(alliance.Id),
-                        $"Open {alliance.Name} on zKill");
-                }
-                else
-                {
-                    AnalysisAllianceTopText.Inlines.Add(new Run(alliance.Name));
-                }
-
-                AnalysisAllianceTopText.Inlines.Add(new Run($" [{alliance.Count}]"));
-            }
-        }
-
-        private void PopulateAnalysisCorpTopText(IReadOnlyList<AnalysisAffiliationSummary> corps)
-        {
-            AnalysisCorpTopText.Inlines.Clear();
-            AnalysisCorpTopText.Inlines.Add(new Run("Top corps: "));
-
-            if (corps.Count == 0)
-            {
-                AnalysisCorpTopText.Inlines.Add(new Run("none visible"));
-                return;
-            }
-
-            for (var index = 0; index < corps.Count; index++)
-            {
-                if (index > 0)
-                {
-                    AnalysisCorpTopText.Inlines.Add(new Run(" | "));
-                }
-
-                var corp = corps[index];
-                if (!string.IsNullOrWhiteSpace(corp.Id) &&
-                    long.TryParse(corp.Id, out _))
-                {
-                    AddHyperlinkInline(
-                        AnalysisCorpTopText,
-                        corp.Name,
-                        BuildCorporationZkillUrl(corp.Id),
-                        $"Open {corp.Name} on zKill");
-                }
-                else
-                {
-                    AnalysisCorpTopText.Inlines.Add(new Run(corp.Name));
-                }
-
-                AnalysisCorpTopText.Inlines.Add(new Run($" [{corp.Count}]"));
-            }
-        }
-
-        private void PopulateAnalysisHighlightsText(IReadOnlyList<AnalysisHighlightSummary> highlights)
-        {
-            AnalysisHighlightsText.Inlines.Clear();
-            AnalysisHighlightsText.Inlines.Add(new Run("Highlights: "));
-
-            var addedAny = false;
-            for (var index = 0; index < highlights.Count; index++)
-            {
-                var highlight = highlights[index];
-                AddHighlightCharacterLink(
-                    AnalysisHighlightsText,
-                    highlight.Label,
-                    highlight.CharacterName,
-                    highlight.CharacterId,
-                    highlight.ValueText,
-                    ref addedAny);
-            }
-
-            if (!addedAny)
-            {
-                AnalysisHighlightsText.Inlines.Add(new Run("none visible"));
-            }
-        }
-
-        private void AddHighlightCharacterLink(
-            TextBlock target,
-            string label,
-            string characterName,
-            string characterId,
-            string valueText,
-            ref bool addedAny)
-        {
-            if (addedAny)
-            {
-                target.Inlines.Add(new Run(" | "));
-            }
-
-            if (!string.IsNullOrWhiteSpace(label))
-            {
-                target.Inlines.Add(new Run($"{label}: "));
-            }
-
-            var hasCharacterId = !string.IsNullOrWhiteSpace(characterId) && long.TryParse(characterId, out _);
-            if (hasCharacterId)
-            {
-                AddHyperlinkInline(
-                    target,
-                    characterName,
-                    _zkillUrlBuilder.BuildCharacterUrl(characterId),
-                    $"Open {characterName} on zKill");
-            }
-            else
-            {
-                target.Inlines.Add(new Run(characterName));
-            }
-
-            target.Inlines.Add(new Run($" [{valueText}]"));
-            addedAny = true;
-        }
-
-        private void AddHyperlinkInline(TextBlock target, string text, string url, string toolTip)
-        {
-            var hyperlink = new Hyperlink(new Run(text))
-            {
-                NavigateUri = Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null,
-                ToolTip = toolTip
-            };
-            hyperlink.RequestNavigate += AnalysisHyperlink_RequestNavigate;
-            target.Inlines.Add(hyperlink);
-        }
-
-        private string BuildAllianceZkillUrl(string allianceId)
-        {
-            return string.IsNullOrWhiteSpace(allianceId)
-                ? string.Empty
-                : $"https://zkillboard.com/alliance/{Uri.EscapeDataString(allianceId.Trim())}/";
-        }
-
-        private string BuildCorporationZkillUrl(string corporationId)
-        {
-            return string.IsNullOrWhiteSpace(corporationId)
-                ? string.Empty
-                : $"https://zkillboard.com/corporation/{Uri.EscapeDataString(corporationId.Trim())}/";
-        }
-
         private void AnalysisHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
             e.Handled = true;
@@ -3608,8 +3414,8 @@ namespace PitmastersGrill
             }
 
             var url = string.Equals(item.EntityType, "alliance", StringComparison.OrdinalIgnoreCase)
-                ? BuildAllianceZkillUrl(item.Id)
-                : BuildCorporationZkillUrl(item.Id);
+                ? _analysisTabPresenter.BuildAllianceZkillUrl(item.Id)
+                : _analysisTabPresenter.BuildCorporationZkillUrl(item.Id);
 
             if (string.IsNullOrWhiteSpace(url))
             {

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -62,6 +62,7 @@ namespace PitmastersGrill
         private readonly MainWindowSettingsCoordinator _mainWindowSettingsCoordinator;
         private readonly BoardDisplaySettingsController _boardDisplaySettingsController;
         private readonly BoardColumnLayoutController _boardColumnLayoutController;
+        private readonly BoardColumnSettingsController _boardColumnSettingsController;
         private readonly SettingsTabController _settingsTabController;
         private readonly AnalysisTabController _analysisTabController;
         private readonly WindowLayoutController _windowLayoutController;
@@ -139,6 +140,9 @@ namespace PitmastersGrill
             _mainWindowAppearanceController = new MainWindowAppearanceController(appSettingsService);
             _boardDisplaySettingsController = new BoardDisplaySettingsController();
             _boardColumnLayoutController = new BoardColumnLayoutController();
+            _boardColumnSettingsController = new BoardColumnSettingsController(
+                _boardColumnLayoutController,
+                settings => _mainWindowAppearanceController.SaveSettings(settings));
             _settingsTabController = new SettingsTabController();
             _mainWindowSettingsCoordinator = new MainWindowSettingsCoordinator(
                 _mainWindowAppearanceController,
@@ -935,7 +939,8 @@ namespace PitmastersGrill
 
         private void InitializeBoardColumnLayoutUi()
         {
-            _boardColumnLayoutController.InitializeColumns(
+            _boardColumnSettingsController.InitializeBoardColumnLayoutUi(
+                ApplyBoardColumnLayout,
                 ("SigColumn", SigColumn),
                 ("CharacterColumn", CharacterColumn),
                 ("AllianceColumn", AllianceColumn),
@@ -946,9 +951,6 @@ namespace PitmastersGrill
                 ("LastShipSeenColumn", LastShipSeenColumn),
                 ("LastSeenColumn", LastSeenColumn),
                 ("CynoHullSeenColumn", CynoHullSeenColumn));
-            _boardColumnLayoutController.ApplyColumnMinimumWidths();
-            _boardColumnLayoutController.BuildCanonicalBoardColumnLayout();
-            ApplyCanonicalBoardColumnLayout("Apply canonical default board layout");
         }
 
         private void ApplyBoardDisplaySettings()
@@ -987,60 +989,52 @@ namespace PitmastersGrill
 
         private void BoardColumnVisibilityCheckBox_Changed(object sender, RoutedEventArgs e)
         {
-            if (_isApplyingSettings)
-            {
-                return;
-            }
-
-            SaveBoardColumnSettingsFromCheckBoxes();
-            ApplyBoardColumnVisibility();
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-
-            AppLogger.UiInfo(
-                $"Board column visibility changed. sig={IsChecked(ShowSigColumnCheckBox)} alliance={IsChecked(ShowAllianceColumnCheckBox)} corp={IsChecked(ShowCorpColumnCheckBox)} kills={IsChecked(ShowKillsColumnCheckBox)} losses={IsChecked(ShowLossesColumnCheckBox)} avgFleet={IsChecked(ShowAvgFleetSizeColumnCheckBox)} lastShip={IsChecked(ShowLastShipSeenColumnCheckBox)} lastSeen={IsChecked(ShowLastSeenColumnCheckBox)} cynoHull={IsChecked(ShowCynoHullSeenColumnCheckBox)}");
+            _boardColumnSettingsController.HandleBoardColumnVisibilityChanged(
+                _isApplyingSettings,
+                _appSettings,
+                ShowSigColumnCheckBox,
+                ShowAllianceColumnCheckBox,
+                ShowCorpColumnCheckBox,
+                ShowKillsColumnCheckBox,
+                ShowLossesColumnCheckBox,
+                ShowAvgFleetSizeColumnCheckBox,
+                ShowLastShipSeenColumnCheckBox,
+                ShowLastSeenColumnCheckBox,
+                ShowCynoHullSeenColumnCheckBox,
+                ApplyBoardColumnVisibility);
         }
 
         private void ShowCorpAllianceCountsCheckBox_Changed(object sender, RoutedEventArgs e)
         {
-            if (_isApplyingSettings)
-            {
-                return;
-            }
-
-            _appSettings.ShowCorpAllianceCounts = ShowCorpAllianceCountsCheckBox.IsChecked == true;
-            RecomputeCorpAllianceCounts();
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-
-            AppLogger.UiInfo($"Corp/alliance board counts changed. enabled={_appSettings.ShowCorpAllianceCounts}");
+            _boardColumnSettingsController.HandleShowCorpAllianceCountsChanged(
+                _isApplyingSettings,
+                _appSettings,
+                ShowCorpAllianceCountsCheckBox.IsChecked == true,
+                RecomputeCorpAllianceCounts);
         }
 
         private void ShowAllBoardColumnsButton_Click(object sender, RoutedEventArgs e)
         {
-            SetAllOptionalBoardColumnSettings(true);
-            ApplyBoardColumnSettingsToCheckBoxes();
-            ApplyBoardColumnVisibility();
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-
-            AppLogger.UiInfo("Board column visibility reset to show all optional columns.");
+            _boardColumnSettingsController.HandleShowAllBoardColumns(
+                _appSettings,
+                ApplyBoardColumnSettingsToCheckBoxes,
+                ApplyBoardColumnVisibility);
         }
 
         private void ResetBoardColumnsButton_Click(object sender, RoutedEventArgs e)
         {
-            SetAllOptionalBoardColumnSettings(true);
-            ApplyBoardColumnSettingsToCheckBoxes();
-            ApplyBoardColumnVisibility();
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-
-            AppLogger.UiInfo("Board column visibility reset to defaults.");
+            _boardColumnSettingsController.HandleResetBoardColumns(
+                _appSettings,
+                ApplyBoardColumnSettingsToCheckBoxes,
+                ApplyBoardColumnVisibility);
         }
 
         private void ResetBoardLayoutButton_Click(object sender, RoutedEventArgs e)
         {
-            _appSettings.BoardColumnLayout.Clear();
-            ApplyCanonicalBoardColumnLayout("Reset board layout to canonical defaults");
-            SaveCurrentBoardColumnLayout("Reset layout");
-
-            AppLogger.UiInfo("Board column layout reset to canonical defaults.");
+            _boardColumnSettingsController.HandleResetBoardLayout(
+                _appSettings,
+                ApplyCanonicalBoardColumnLayout,
+                SaveCurrentBoardColumnLayout);
         }
 
         private void ApplyBoardColumnSettingsToCheckBoxes()
@@ -1055,7 +1049,7 @@ namespace PitmastersGrill
 
             try
             {
-                _boardColumnLayoutController.ApplyBoardColumnSettingsToCheckBoxes(
+                _boardColumnSettingsController.ApplyBoardColumnSettingsToCheckBoxes(
                     _appSettings,
                     ShowSigColumnCheckBox,
                     ShowAllianceColumnCheckBox,
@@ -1076,7 +1070,7 @@ namespace PitmastersGrill
 
         private void SaveBoardColumnSettingsFromCheckBoxes()
         {
-            _boardColumnLayoutController.SaveBoardColumnSettingsFromCheckBoxes(
+            _boardColumnSettingsController.SaveBoardColumnSettingsFromCheckBoxes(
                 _appSettings,
                 ShowSigColumnCheckBox,
                 ShowAllianceColumnCheckBox,
@@ -1095,7 +1089,7 @@ namespace PitmastersGrill
 
             try
             {
-                _boardColumnLayoutController.ApplyBoardColumnVisibility(_appSettings);
+                _boardColumnSettingsController.ApplyBoardColumnVisibility(_appSettings);
             }
             finally
             {
@@ -1443,16 +1437,6 @@ namespace PitmastersGrill
         }
 
         private sealed record BoardColumnFitPlan(DataGridColumn Column, double MinimumWidth, double CurrentWidth);
-
-        private void SetAllOptionalBoardColumnSettings(bool isVisible)
-        {
-            _boardColumnLayoutController.SetAllOptionalBoardColumnSettings(_appSettings, isVisible);
-        }
-
-        private static bool IsChecked(CheckBox checkBox)
-        {
-            return checkBox.IsChecked == true;
-        }
 
         private void KnownCynoOverrideCheckBox_Changed(object sender, RoutedEventArgs e)
         {

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -63,6 +63,7 @@ namespace PitmastersGrill
         private readonly BoardDisplaySettingsController _boardDisplaySettingsController;
         private readonly BoardColumnLayoutController _boardColumnLayoutController;
         private readonly BoardColumnSettingsController _boardColumnSettingsController;
+        private readonly BoardColumnLayoutPersistenceController _boardColumnLayoutPersistenceController;
         private readonly SettingsTabController _settingsTabController;
         private readonly AnalysisTabController _analysisTabController;
         private readonly WindowLayoutController _windowLayoutController;
@@ -116,12 +117,7 @@ namespace PitmastersGrill
         private Rect _lastKnownNormalBounds = Rect.Empty;
         private string? _activeBoardSortMemberPath;
         private ListSortDirection? _activeBoardSortDirection;
-        private string _pendingBoardColumnLayoutSaveReason = string.Empty;
-        private DependencyPropertyDescriptor? _boardColumnWidthDescriptor;
         private bool? _lastAppliedCompactMode;
-        private bool _isApplyingBoardColumnLayout;
-        private bool _isBoardColumnAutoFitPending;
-        private bool _isBoardColumnLayoutReadyForPersistence;
         private bool _globalResetWindowHotKeyRegistered;
         private bool _globalClearBoardHotKeyRegistered;
         private bool _globalToggleBoardModeHotKeyRegistered;
@@ -141,6 +137,9 @@ namespace PitmastersGrill
             _boardDisplaySettingsController = new BoardDisplaySettingsController();
             _boardColumnLayoutController = new BoardColumnLayoutController();
             _boardColumnSettingsController = new BoardColumnSettingsController(
+                _boardColumnLayoutController,
+                settings => _mainWindowAppearanceController.SaveSettings(settings));
+            _boardColumnLayoutPersistenceController = new BoardColumnLayoutPersistenceController(
                 _boardColumnLayoutController,
                 settings => _mainWindowAppearanceController.SaveSettings(settings));
             _settingsTabController = new SettingsTabController();
@@ -1085,60 +1084,17 @@ namespace PitmastersGrill
 
         private void ApplyBoardColumnVisibility()
         {
-            _isApplyingBoardColumnLayout = true;
-
-            try
-            {
-                _boardColumnSettingsController.ApplyBoardColumnVisibility(_appSettings);
-            }
-            finally
-            {
-                _isApplyingBoardColumnLayout = false;
-            }
-
+            _boardColumnLayoutPersistenceController.RunWhileApplyingBoardColumnLayout(
+                () => _boardColumnSettingsController.ApplyBoardColumnVisibility(_appSettings));
             ScheduleFitVisibleBoardColumnsToViewport(force: true);
-        }
-
-        private void HookBoardColumnWidthTracking()
-        {
-            if (_boardColumnWidthDescriptor != null)
-            {
-                return;
-            }
-
-            _boardColumnWidthDescriptor = DependencyPropertyDescriptor.FromProperty(
-                DataGridColumn.WidthProperty,
-                typeof(DataGridColumn));
-
-            if (_boardColumnWidthDescriptor == null)
-            {
-                AppLogger.UiWarn("Board column width tracking could not be initialized.");
-                return;
-            }
-
-            foreach (var column in _boardColumnLayoutController.BoardColumnsByKey.Values)
-            {
-                _boardColumnWidthDescriptor.AddValueChanged(column, BoardColumnWidth_ValueChanged);
-            }
         }
 
         private void ApplySavedBoardColumnLayout()
         {
-            if (_appSettings.BoardColumnLayout == null || _appSettings.BoardColumnLayout.Count == 0)
-            {
-                return;
-            }
-
-            if (!_boardColumnLayoutController.TryValidateSavedBoardColumnLayout(_appSettings.BoardColumnLayout, out var validSavedSettings, out var validationFailureReason))
-            {
-                AppLogger.UiWarn($"Saved board column layout discarded. reason='{validationFailureReason}'");
-                _appSettings.BoardColumnLayout.Clear();
-                _mainWindowAppearanceController.SaveSettings(_appSettings);
-                ApplyCanonicalBoardColumnLayout("Discard invalid saved board layout");
-                return;
-            }
-
-            ApplyBoardColumnLayout(validSavedSettings, "Restore saved board layout");
+            _boardColumnLayoutPersistenceController.ApplySavedBoardColumnLayout(
+                _appSettings,
+                ApplyBoardColumnLayout,
+                ApplyCanonicalBoardColumnLayout);
         }
 
         private void ApplyCanonicalBoardColumnLayout(string reason)
@@ -1148,24 +1104,10 @@ namespace PitmastersGrill
 
         private void ApplyBoardColumnLayout(IEnumerable<BoardColumnLayoutSetting> layoutSettings, string reason)
         {
-            if (layoutSettings == null)
-            {
-                return;
-            }
-
-            _isApplyingBoardColumnLayout = true;
-
-            try
-            {
-                _boardColumnLayoutController.ApplyBoardColumnLayout(layoutSettings);
-                ScheduleFitVisibleBoardColumnsToViewport();
-
-                AppLogger.UiInfo($"Board column layout applied. reason='{reason}'");
-            }
-            finally
-            {
-                _isApplyingBoardColumnLayout = false;
-            }
+            _boardColumnLayoutPersistenceController.ApplyBoardColumnLayout(
+                layoutSettings,
+                () => ScheduleFitVisibleBoardColumnsToViewport(),
+                reason);
         }
 
         private void PilotBoard_ColumnReordered(object sender, DataGridColumnEventArgs e)
@@ -1186,64 +1128,39 @@ namespace PitmastersGrill
 
         private void ScheduleBoardColumnLayoutSave(string reason)
         {
-            if (_isApplyingSettings || _isApplyingBoardColumnLayout || !CanPersistBoardColumnLayout())
+            if (!_boardColumnLayoutPersistenceController.TryQueueBoardColumnLayoutSave(
+                _isApplyingSettings,
+                IsBoardLayoutHostReady,
+                reason))
             {
                 return;
             }
 
             _boardColumnLayoutSaveTimer.Stop();
-            _pendingBoardColumnLayoutSaveReason = reason;
             _boardColumnLayoutSaveTimer.Start();
         }
 
         private void BoardColumnLayoutSaveTimer_Tick(object? sender, EventArgs e)
         {
             _boardColumnLayoutSaveTimer.Stop();
-            var reason = string.IsNullOrWhiteSpace(_pendingBoardColumnLayoutSaveReason)
-                ? "Board layout changed"
-                : _pendingBoardColumnLayoutSaveReason;
-            _pendingBoardColumnLayoutSaveReason = string.Empty;
-            SaveCurrentBoardColumnLayout(reason);
+            SaveCurrentBoardColumnLayout(_boardColumnLayoutPersistenceController.DequeuePendingBoardColumnLayoutSaveReason());
         }
 
         private void SaveCurrentBoardColumnLayout(string reason)
         {
-            if (!CanPersistBoardColumnLayout())
-            {
-                AppLogger.UiDebug($"Board column layout save skipped. reason='{reason}' hostReady=false");
-                return;
-            }
-
-            var currentLayout = _boardColumnLayoutController.CaptureCurrentBoardColumnLayout();
-
-            if (!_boardColumnLayoutController.TryValidateSavedBoardColumnLayout(currentLayout, out var sanitizedLayout, out var validationFailureReason))
-            {
-                AppLogger.UiWarn($"Board column layout save skipped. reason='{reason}' validationFailure='{validationFailureReason}'");
-                return;
-            }
-
-            if (_boardColumnLayoutController.BoardColumnLayoutsMatch(_appSettings.BoardColumnLayout, sanitizedLayout))
-            {
-                return;
-            }
-
-            _appSettings.BoardColumnLayout = sanitizedLayout;
-            _mainWindowAppearanceController.SaveSettings(_appSettings);
-            AppLogger.UiInfo($"Board column layout saved. reason='{reason}'");
+            _boardColumnLayoutPersistenceController.SaveCurrentBoardColumnLayout(
+                _appSettings,
+                IsBoardLayoutHostReady,
+                reason);
         }
 
         private void FinalizeBoardColumnLayoutInitialization()
         {
             ApplyCanonicalBoardColumnLayout("Finalize board layout after load");
             ApplySavedBoardColumnLayout();
-            HookBoardColumnWidthTracking();
-            _isBoardColumnLayoutReadyForPersistence = true;
+            _boardColumnLayoutPersistenceController.EnsureBoardColumnWidthTracking(BoardColumnWidth_ValueChanged);
+            _boardColumnLayoutPersistenceController.MarkBoardColumnLayoutReady();
             AppLogger.UiInfo($"Board column layout initialization complete. hostReady={IsBoardLayoutHostReady()} actualWidth={PilotBoard?.ActualWidth ?? 0:0.##}");
-        }
-
-        private bool CanPersistBoardColumnLayout()
-        {
-            return _isBoardColumnLayoutReadyForPersistence && IsBoardLayoutHostReady();
         }
 
         private bool IsBoardLayoutHostReady()
@@ -1256,187 +1173,23 @@ namespace PitmastersGrill
 
         private void ScheduleFitVisibleBoardColumnsToViewport(bool force = false)
         {
-            if (PilotBoard == null)
+            if (!_boardColumnLayoutPersistenceController.TryQueueFitVisibleBoardColumnsToViewport(PilotBoard, force))
             {
                 return;
             }
 
-            if (_isBoardColumnAutoFitPending && !force)
-            {
-                return;
-            }
-
-            _isBoardColumnAutoFitPending = true;
             Dispatcher.BeginInvoke(
                 new Action(() =>
                 {
-                    _isBoardColumnAutoFitPending = false;
-                    FitVisibleBoardColumnsToViewport();
+                    _boardColumnLayoutPersistenceController.CompleteQueuedFitVisibleBoardColumnsToViewport(PilotBoard);
                 }),
                 DispatcherPriority.ContextIdle);
         }
 
-        private double GetPilotBoardViewportWidth()
-        {
-            if (PilotBoard == null)
-            {
-                return 0d;
-            }
-
-            try
-            {
-                var scrollViewer = FindVisualDescendant<ScrollViewer>(PilotBoard);
-                if (scrollViewer != null && scrollViewer.ViewportWidth > 0d)
-                {
-                    // Subtract a single device-independent pixel as a safety margin so WPF
-                    // does not decide a horizontal scrollbar is required from rounding.
-                    return Math.Max(0d, scrollViewer.ViewportWidth - 1d);
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Visual tree may not be ready during early layout passes. Fall back below.
-            }
-
-            return Math.Max(0d, PilotBoard.ActualWidth - 1d);
-        }
-
         private void FitVisibleBoardColumnsToViewport()
         {
-            if (PilotBoard == null || _boardColumnLayoutController.BoardColumnsByKey.Count == 0 || PilotBoard.ActualWidth <= 0)
-            {
-                return;
-            }
-
-            PilotBoard.UpdateLayout();
-
-            var visibleColumns = _boardColumnLayoutController.BoardColumnsByKey.Values
-                .Where(column => column.Visibility == Visibility.Visible)
-                .OrderBy(column => column.DisplayIndex)
-                .ToList();
-
-            if (visibleColumns.Count == 0)
-            {
-                return;
-            }
-
-            var availableWidth = GetPilotBoardViewportWidth();
-            if (double.IsNaN(availableWidth) || double.IsInfinity(availableWidth) || availableWidth <= 40d)
-            {
-                return;
-            }
-
-            var columnPlans = visibleColumns
-                .Select(column =>
-                {
-                    var key = _boardColumnLayoutController.GetBoardColumnKey(column);
-                    var minimum = Math.Max(12d, _boardColumnLayoutController.GetBoardColumnMinimumWidth(key));
-                    var current = Math.Max(minimum, GetEffectiveBoardColumnWidth(column));
-                    return new BoardColumnFitPlan(column, minimum, current);
-                })
-                .ToList();
-
-            var minimumTotal = columnPlans.Sum(plan => plan.MinimumWidth);
-            var preferredTotal = columnPlans.Sum(plan => plan.CurrentWidth);
-
-            if (minimumTotal <= 0d || preferredTotal <= 0d)
-            {
-                return;
-            }
-
-            var wasApplyingLayout = _isApplyingBoardColumnLayout;
-            _isApplyingBoardColumnLayout = true;
-
-            try
-            {
-                if (minimumTotal >= availableWidth)
-                {
-                    var scale = Math.Max(0.6d, availableWidth / minimumTotal);
-                    foreach (var plan in columnPlans)
-                    {
-                        SetBoardColumnPixelWidth(plan.Column, Math.Max(18d, plan.MinimumWidth * scale));
-                    }
-
-                    return;
-                }
-
-                if (preferredTotal > availableWidth)
-                {
-                    var shortage = preferredTotal - availableWidth;
-                    var shrinkCapacity = columnPlans.Sum(plan => Math.Max(0d, plan.CurrentWidth - plan.MinimumWidth));
-
-                    foreach (var plan in columnPlans)
-                    {
-                        var targetWidth = plan.CurrentWidth;
-                        if (shrinkCapacity > 0d)
-                        {
-                            var share = Math.Max(0d, plan.CurrentWidth - plan.MinimumWidth) / shrinkCapacity;
-                            targetWidth = Math.Max(plan.MinimumWidth, plan.CurrentWidth - shortage * share);
-                        }
-
-                        SetBoardColumnPixelWidth(plan.Column, targetWidth);
-                    }
-
-                    return;
-                }
-
-                var extra = availableWidth - preferredTotal;
-                var expandableTotal = columnPlans.Sum(plan => Math.Max(plan.MinimumWidth, plan.CurrentWidth));
-                foreach (var plan in columnPlans)
-                {
-                    var share = expandableTotal > 0d
-                        ? Math.Max(plan.MinimumWidth, plan.CurrentWidth) / expandableTotal
-                        : 1d / columnPlans.Count;
-                    SetBoardColumnPixelWidth(plan.Column, plan.CurrentWidth + extra * share);
-                }
-            }
-            finally
-            {
-                _isApplyingBoardColumnLayout = wasApplyingLayout;
-            }
+            _boardColumnLayoutPersistenceController.FitVisibleBoardColumnsToViewport(PilotBoard);
         }
-
-        private static void SetBoardColumnPixelWidth(DataGridColumn column, double width)
-        {
-            if (column == null || double.IsNaN(width) || double.IsInfinity(width) || width <= 0d)
-            {
-                return;
-            }
-
-            var roundedWidth = Math.Round(width, 1);
-            if (Math.Abs(GetEffectiveBoardColumnWidth(column) - roundedWidth) < 0.5d &&
-                column.Width.UnitType == DataGridLengthUnitType.Pixel)
-            {
-                return;
-            }
-
-            column.Width = new DataGridLength(roundedWidth, DataGridLengthUnitType.Pixel);
-        }
-
-        private static double GetEffectiveBoardColumnWidth(DataGridColumn column)
-        {
-            if (column == null)
-            {
-                return 0d;
-            }
-
-            var width = column.ActualWidth;
-            if (double.IsNaN(width) || double.IsInfinity(width) || width <= 0)
-            {
-                width = column.Width.DisplayValue;
-            }
-
-            if (double.IsNaN(width) || double.IsInfinity(width) || width <= 0)
-            {
-                width = column.MinWidth;
-            }
-
-            return double.IsNaN(width) || double.IsInfinity(width) || width <= 0
-                ? 0d
-                : width;
-        }
-
-        private sealed record BoardColumnFitPlan(DataGridColumn Column, double MinimumWidth, double CurrentWidth);
 
         private void KnownCynoOverrideCheckBox_Changed(object sender, RoutedEventArgs e)
         {

--- a/PitmastersGrill/Services/AnalysisTabPresenter.cs
+++ b/PitmastersGrill/Services/AnalysisTabPresenter.cs
@@ -1,0 +1,243 @@
+using PitmastersGrill.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Navigation;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class AnalysisTabPresenter
+    {
+        private readonly AnalysisTabController _analysisTabController;
+        private readonly ZkillUrlBuilder _zkillUrlBuilder;
+        private readonly RequestNavigateEventHandler _analysisHyperlinkRequestNavigate;
+        private readonly TextBlock? _boardSummaryText;
+        private readonly TextBlock? _analysisEmptyStateText;
+        private readonly UIElement? _analysisDetailsPanel;
+        private readonly TextBlock? _analysisVisibleCountsText;
+        private readonly TextBlock? _analysisUniqueCountsText;
+        private readonly TextBlock? _analysisAllianceTopText;
+        private readonly TextBlock? _analysisCorpTopText;
+        private readonly TextBlock? _analysisSignalsText;
+        private readonly TextBlock? _analysisHighlightsText;
+        private readonly ObservableCollection<AnalysisAffiliationListItem> _analysisAllianceItems;
+        private readonly ObservableCollection<AnalysisAffiliationListItem> _analysisCorpItems;
+
+        public AnalysisTabPresenter(
+            AnalysisTabController analysisTabController,
+            ZkillUrlBuilder zkillUrlBuilder,
+            RequestNavigateEventHandler analysisHyperlinkRequestNavigate,
+            TextBlock? boardSummaryText,
+            TextBlock? analysisEmptyStateText,
+            UIElement? analysisDetailsPanel,
+            TextBlock? analysisVisibleCountsText,
+            TextBlock? analysisUniqueCountsText,
+            TextBlock? analysisAllianceTopText,
+            TextBlock? analysisCorpTopText,
+            TextBlock? analysisSignalsText,
+            TextBlock? analysisHighlightsText,
+            ObservableCollection<AnalysisAffiliationListItem> analysisAllianceItems,
+            ObservableCollection<AnalysisAffiliationListItem> analysisCorpItems)
+        {
+            _analysisTabController = analysisTabController ?? throw new ArgumentNullException(nameof(analysisTabController));
+            _zkillUrlBuilder = zkillUrlBuilder ?? throw new ArgumentNullException(nameof(zkillUrlBuilder));
+            _analysisHyperlinkRequestNavigate = analysisHyperlinkRequestNavigate ?? throw new ArgumentNullException(nameof(analysisHyperlinkRequestNavigate));
+            _boardSummaryText = boardSummaryText;
+            _analysisEmptyStateText = analysisEmptyStateText;
+            _analysisDetailsPanel = analysisDetailsPanel;
+            _analysisVisibleCountsText = analysisVisibleCountsText;
+            _analysisUniqueCountsText = analysisUniqueCountsText;
+            _analysisAllianceTopText = analysisAllianceTopText;
+            _analysisCorpTopText = analysisCorpTopText;
+            _analysisSignalsText = analysisSignalsText;
+            _analysisHighlightsText = analysisHighlightsText;
+            _analysisAllianceItems = analysisAllianceItems ?? throw new ArgumentNullException(nameof(analysisAllianceItems));
+            _analysisCorpItems = analysisCorpItems ?? throw new ArgumentNullException(nameof(analysisCorpItems));
+        }
+
+        public void UpdateBoardSummary(IReadOnlyList<PilotBoardRow> currentRows)
+        {
+            if (_boardSummaryText == null)
+            {
+                return;
+            }
+
+            _boardSummaryText.Text = BoardSummaryTextBuilder.Build(currentRows);
+        }
+
+        public void UpdateAnalysisTab(IReadOnlyList<PilotBoardRow> currentRows)
+        {
+            if (_analysisEmptyStateText == null ||
+                _analysisDetailsPanel == null ||
+                _analysisVisibleCountsText == null ||
+                _analysisUniqueCountsText == null ||
+                _analysisAllianceTopText == null ||
+                _analysisCorpTopText == null ||
+                _analysisSignalsText == null ||
+                _analysisHighlightsText == null)
+            {
+                return;
+            }
+
+            var summary = _analysisTabController.BuildSummary(currentRows);
+            if (!summary.HasVisibleRows)
+            {
+                _analysisEmptyStateText.Visibility = Visibility.Visible;
+                _analysisDetailsPanel.Visibility = Visibility.Collapsed;
+                _analysisEmptyStateText.Text = summary.EmptyStateText;
+                return;
+            }
+
+            _analysisEmptyStateText.Visibility = Visibility.Collapsed;
+            _analysisDetailsPanel.Visibility = Visibility.Visible;
+            _analysisVisibleCountsText.Text = summary.VisibleCountsText;
+            _analysisUniqueCountsText.Text = summary.UniqueCountsText;
+            PopulateAnalysisAffiliationSummaryText(_analysisAllianceTopText, "Top alliances: ", summary.TopAlliances, BuildAllianceZkillUrl);
+            PopulateAnalysisAffiliationSummaryText(_analysisCorpTopText, "Top corps: ", summary.TopCorps, BuildCorporationZkillUrl);
+            PopulateAnalysisAffiliationList(_analysisAllianceItems, _analysisTabController.BuildAffiliationListItems(summary.AllAlliances, "alliance"));
+            PopulateAnalysisAffiliationList(_analysisCorpItems, _analysisTabController.BuildAffiliationListItems(summary.AllCorps, "corporation"));
+            _analysisSignalsText.Text = string.Empty;
+            PopulateAnalysisHighlightsText(summary.Highlights);
+        }
+
+        public string BuildAllianceZkillUrl(string allianceId)
+        {
+            return string.IsNullOrWhiteSpace(allianceId)
+                ? string.Empty
+                : $"https://zkillboard.com/alliance/{Uri.EscapeDataString(allianceId.Trim())}/";
+        }
+
+        public string BuildCorporationZkillUrl(string corporationId)
+        {
+            return string.IsNullOrWhiteSpace(corporationId)
+                ? string.Empty
+                : $"https://zkillboard.com/corporation/{Uri.EscapeDataString(corporationId.Trim())}/";
+        }
+
+        private void PopulateAnalysisAffiliationSummaryText(
+            TextBlock target,
+            string prefix,
+            IReadOnlyList<AnalysisAffiliationSummary> summaries,
+            Func<string, string> buildUrl)
+        {
+            target.Inlines.Clear();
+            target.Inlines.Add(new Run(prefix));
+
+            if (summaries.Count == 0)
+            {
+                target.Inlines.Add(new Run("none visible"));
+                return;
+            }
+
+            for (var index = 0; index < summaries.Count; index++)
+            {
+                if (index > 0)
+                {
+                    target.Inlines.Add(new Run(" | "));
+                }
+
+                var summary = summaries[index];
+                if (!string.IsNullOrWhiteSpace(summary.Id) &&
+                    long.TryParse(summary.Id, out _))
+                {
+                    AddHyperlinkInline(
+                        target,
+                        summary.Name,
+                        buildUrl(summary.Id),
+                        $"Open {summary.Name} on zKill");
+                }
+                else
+                {
+                    target.Inlines.Add(new Run(summary.Name));
+                }
+
+                target.Inlines.Add(new Run($" [{summary.Count}]"));
+            }
+        }
+
+        private void PopulateAnalysisHighlightsText(IReadOnlyList<AnalysisHighlightSummary> highlights)
+        {
+            _analysisHighlightsText!.Inlines.Clear();
+            _analysisHighlightsText.Inlines.Add(new Run("Highlights: "));
+
+            var addedAny = false;
+            for (var index = 0; index < highlights.Count; index++)
+            {
+                var highlight = highlights[index];
+                AddHighlightCharacterLink(
+                    _analysisHighlightsText,
+                    highlight.Label,
+                    highlight.CharacterName,
+                    highlight.CharacterId,
+                    highlight.ValueText,
+                    ref addedAny);
+            }
+
+            if (!addedAny)
+            {
+                _analysisHighlightsText.Inlines.Add(new Run("none visible"));
+            }
+        }
+
+        private void AddHighlightCharacterLink(
+            TextBlock target,
+            string label,
+            string characterName,
+            string characterId,
+            string valueText,
+            ref bool addedAny)
+        {
+            if (addedAny)
+            {
+                target.Inlines.Add(new Run(" | "));
+            }
+
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                target.Inlines.Add(new Run($"{label}: "));
+            }
+
+            var hasCharacterId = !string.IsNullOrWhiteSpace(characterId) && long.TryParse(characterId, out _);
+            if (hasCharacterId)
+            {
+                AddHyperlinkInline(
+                    target,
+                    characterName,
+                    _zkillUrlBuilder.BuildCharacterUrl(characterId),
+                    $"Open {characterName} on zKill");
+            }
+            else
+            {
+                target.Inlines.Add(new Run(characterName));
+            }
+
+            target.Inlines.Add(new Run($" [{valueText}]"));
+            addedAny = true;
+        }
+
+        private void AddHyperlinkInline(TextBlock target, string text, string url, string toolTip)
+        {
+            var hyperlink = new Hyperlink(new Run(text))
+            {
+                NavigateUri = Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null,
+                ToolTip = toolTip
+            };
+            hyperlink.RequestNavigate += _analysisHyperlinkRequestNavigate;
+            target.Inlines.Add(hyperlink);
+        }
+
+        private static void PopulateAnalysisAffiliationList(
+            ObservableCollection<AnalysisAffiliationListItem> target,
+            IReadOnlyList<AnalysisAffiliationListItem> items)
+        {
+            target.Clear();
+            foreach (var item in items)
+            {
+                target.Add(item);
+            }
+        }
+    }
+}

--- a/PitmastersGrill/Services/BoardColumnLayoutPersistenceController.cs
+++ b/PitmastersGrill/Services/BoardColumnLayoutPersistenceController.cs
@@ -1,0 +1,417 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class BoardColumnLayoutPersistenceController
+    {
+        private readonly BoardColumnLayoutController _boardColumnLayoutController;
+        private readonly Action<AppSettings> _saveSettings;
+        private string _pendingBoardColumnLayoutSaveReason = string.Empty;
+        private DependencyPropertyDescriptor? _boardColumnWidthDescriptor;
+        private bool _isBoardColumnAutoFitPending;
+        private bool _isBoardColumnLayoutReadyForPersistence;
+
+        public BoardColumnLayoutPersistenceController(
+            BoardColumnLayoutController boardColumnLayoutController,
+            Action<AppSettings> saveSettings)
+        {
+            _boardColumnLayoutController = boardColumnLayoutController ?? throw new ArgumentNullException(nameof(boardColumnLayoutController));
+            _saveSettings = saveSettings ?? throw new ArgumentNullException(nameof(saveSettings));
+        }
+
+        public bool IsApplyingBoardColumnLayout { get; private set; }
+
+        public void RunWhileApplyingBoardColumnLayout(Action action)
+        {
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            var wasApplyingLayout = IsApplyingBoardColumnLayout;
+            IsApplyingBoardColumnLayout = true;
+
+            try
+            {
+                action();
+            }
+            finally
+            {
+                IsApplyingBoardColumnLayout = wasApplyingLayout;
+            }
+        }
+
+        public void EnsureBoardColumnWidthTracking(EventHandler widthChangedHandler)
+        {
+            if (widthChangedHandler == null)
+            {
+                throw new ArgumentNullException(nameof(widthChangedHandler));
+            }
+
+            if (_boardColumnWidthDescriptor != null)
+            {
+                return;
+            }
+
+            _boardColumnWidthDescriptor = DependencyPropertyDescriptor.FromProperty(
+                DataGridColumn.WidthProperty,
+                typeof(DataGridColumn));
+
+            if (_boardColumnWidthDescriptor == null)
+            {
+                AppLogger.UiWarn("Board column width tracking could not be initialized.");
+                return;
+            }
+
+            foreach (var column in _boardColumnLayoutController.BoardColumnsByKey.Values)
+            {
+                _boardColumnWidthDescriptor.AddValueChanged(column, widthChangedHandler);
+            }
+        }
+
+        public void ApplySavedBoardColumnLayout(
+            AppSettings settings,
+            Action<IEnumerable<BoardColumnLayoutSetting>, string> applyBoardColumnLayout,
+            Action<string> applyCanonicalBoardColumnLayout)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (applyBoardColumnLayout == null)
+            {
+                throw new ArgumentNullException(nameof(applyBoardColumnLayout));
+            }
+
+            if (applyCanonicalBoardColumnLayout == null)
+            {
+                throw new ArgumentNullException(nameof(applyCanonicalBoardColumnLayout));
+            }
+
+            if (settings.BoardColumnLayout == null || settings.BoardColumnLayout.Count == 0)
+            {
+                return;
+            }
+
+            if (!_boardColumnLayoutController.TryValidateSavedBoardColumnLayout(settings.BoardColumnLayout, out var validSavedSettings, out var validationFailureReason))
+            {
+                AppLogger.UiWarn($"Saved board column layout discarded. reason='{validationFailureReason}'");
+                settings.BoardColumnLayout.Clear();
+                _saveSettings(settings);
+                applyCanonicalBoardColumnLayout("Discard invalid saved board layout");
+                return;
+            }
+
+            applyBoardColumnLayout(validSavedSettings, "Restore saved board layout");
+        }
+
+        public void ApplyBoardColumnLayout(
+            IEnumerable<BoardColumnLayoutSetting> layoutSettings,
+            Action scheduleFitVisibleBoardColumnsToViewport,
+            string reason)
+        {
+            if (layoutSettings == null)
+            {
+                return;
+            }
+
+            if (scheduleFitVisibleBoardColumnsToViewport == null)
+            {
+                throw new ArgumentNullException(nameof(scheduleFitVisibleBoardColumnsToViewport));
+            }
+
+            RunWhileApplyingBoardColumnLayout(() =>
+            {
+                _boardColumnLayoutController.ApplyBoardColumnLayout(layoutSettings);
+                scheduleFitVisibleBoardColumnsToViewport();
+                AppLogger.UiInfo($"Board column layout applied. reason='{reason}'");
+            });
+        }
+
+        public void MarkBoardColumnLayoutReady()
+        {
+            _isBoardColumnLayoutReadyForPersistence = true;
+        }
+
+        public bool CanPersistBoardColumnLayout(Func<bool> isBoardLayoutHostReady)
+        {
+            if (isBoardLayoutHostReady == null)
+            {
+                throw new ArgumentNullException(nameof(isBoardLayoutHostReady));
+            }
+
+            return _isBoardColumnLayoutReadyForPersistence && isBoardLayoutHostReady();
+        }
+
+        public bool TryQueueBoardColumnLayoutSave(
+            bool isApplyingSettings,
+            Func<bool> isBoardLayoutHostReady,
+            string reason)
+        {
+            if (isBoardLayoutHostReady == null)
+            {
+                throw new ArgumentNullException(nameof(isBoardLayoutHostReady));
+            }
+
+            if (isApplyingSettings || IsApplyingBoardColumnLayout || !CanPersistBoardColumnLayout(isBoardLayoutHostReady))
+            {
+                return false;
+            }
+
+            _pendingBoardColumnLayoutSaveReason = reason;
+            return true;
+        }
+
+        public string DequeuePendingBoardColumnLayoutSaveReason()
+        {
+            var reason = string.IsNullOrWhiteSpace(_pendingBoardColumnLayoutSaveReason)
+                ? "Board layout changed"
+                : _pendingBoardColumnLayoutSaveReason;
+            _pendingBoardColumnLayoutSaveReason = string.Empty;
+            return reason;
+        }
+
+        public void SaveCurrentBoardColumnLayout(
+            AppSettings settings,
+            Func<bool> isBoardLayoutHostReady,
+            string reason)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (isBoardLayoutHostReady == null)
+            {
+                throw new ArgumentNullException(nameof(isBoardLayoutHostReady));
+            }
+
+            if (!CanPersistBoardColumnLayout(isBoardLayoutHostReady))
+            {
+                AppLogger.UiDebug($"Board column layout save skipped. reason='{reason}' hostReady=false");
+                return;
+            }
+
+            var currentLayout = _boardColumnLayoutController.CaptureCurrentBoardColumnLayout();
+
+            if (!_boardColumnLayoutController.TryValidateSavedBoardColumnLayout(currentLayout, out var sanitizedLayout, out var validationFailureReason))
+            {
+                AppLogger.UiWarn($"Board column layout save skipped. reason='{reason}' validationFailure='{validationFailureReason}'");
+                return;
+            }
+
+            if (_boardColumnLayoutController.BoardColumnLayoutsMatch(settings.BoardColumnLayout, sanitizedLayout))
+            {
+                return;
+            }
+
+            settings.BoardColumnLayout = sanitizedLayout;
+            _saveSettings(settings);
+            AppLogger.UiInfo($"Board column layout saved. reason='{reason}'");
+        }
+
+        public bool TryQueueFitVisibleBoardColumnsToViewport(DataGrid? pilotBoard, bool force = false)
+        {
+            if (pilotBoard == null)
+            {
+                return false;
+            }
+
+            if (_isBoardColumnAutoFitPending && !force)
+            {
+                return false;
+            }
+
+            _isBoardColumnAutoFitPending = true;
+            return true;
+        }
+
+        public void CompleteQueuedFitVisibleBoardColumnsToViewport(DataGrid? pilotBoard)
+        {
+            _isBoardColumnAutoFitPending = false;
+            FitVisibleBoardColumnsToViewport(pilotBoard);
+        }
+
+        public void FitVisibleBoardColumnsToViewport(DataGrid? pilotBoard)
+        {
+            if (pilotBoard == null || _boardColumnLayoutController.BoardColumnsByKey.Count == 0 || pilotBoard.ActualWidth <= 0)
+            {
+                return;
+            }
+
+            pilotBoard.UpdateLayout();
+            FitVisibleBoardColumnsToWidth(GetPilotBoardViewportWidth(pilotBoard));
+        }
+
+        public void FitVisibleBoardColumnsToWidth(double availableWidth)
+        {
+            var visibleColumns = _boardColumnLayoutController.BoardColumnsByKey.Values
+                .Where(column => column.Visibility == Visibility.Visible)
+                .OrderBy(column => column.DisplayIndex)
+                .ToList();
+
+            if (visibleColumns.Count == 0 || double.IsNaN(availableWidth) || double.IsInfinity(availableWidth) || availableWidth <= 40d)
+            {
+                return;
+            }
+
+            var columnPlans = visibleColumns
+                .Select(column =>
+                {
+                    var key = _boardColumnLayoutController.GetBoardColumnKey(column);
+                    var minimum = Math.Max(12d, _boardColumnLayoutController.GetBoardColumnMinimumWidth(key));
+                    var current = Math.Max(minimum, GetEffectiveBoardColumnWidth(column));
+                    return new BoardColumnFitPlan(column, minimum, current);
+                })
+                .ToList();
+
+            var minimumTotal = columnPlans.Sum(plan => plan.MinimumWidth);
+            var preferredTotal = columnPlans.Sum(plan => plan.CurrentWidth);
+
+            if (minimumTotal <= 0d || preferredTotal <= 0d)
+            {
+                return;
+            }
+
+            RunWhileApplyingBoardColumnLayout(() =>
+            {
+                if (minimumTotal >= availableWidth)
+                {
+                    var scale = Math.Max(0.6d, availableWidth / minimumTotal);
+                    foreach (var plan in columnPlans)
+                    {
+                        SetBoardColumnPixelWidth(plan.Column, Math.Max(18d, plan.MinimumWidth * scale));
+                    }
+
+                    return;
+                }
+
+                if (preferredTotal > availableWidth)
+                {
+                    var shortage = preferredTotal - availableWidth;
+                    var shrinkCapacity = columnPlans.Sum(plan => Math.Max(0d, plan.CurrentWidth - plan.MinimumWidth));
+
+                    foreach (var plan in columnPlans)
+                    {
+                        var targetWidth = plan.CurrentWidth;
+                        if (shrinkCapacity > 0d)
+                        {
+                            var share = Math.Max(0d, plan.CurrentWidth - plan.MinimumWidth) / shrinkCapacity;
+                            targetWidth = Math.Max(plan.MinimumWidth, plan.CurrentWidth - shortage * share);
+                        }
+
+                        SetBoardColumnPixelWidth(plan.Column, targetWidth);
+                    }
+
+                    return;
+                }
+
+                var extra = availableWidth - preferredTotal;
+                var expandableTotal = columnPlans.Sum(plan => Math.Max(plan.MinimumWidth, plan.CurrentWidth));
+                foreach (var plan in columnPlans)
+                {
+                    var share = expandableTotal > 0d
+                        ? Math.Max(plan.MinimumWidth, plan.CurrentWidth) / expandableTotal
+                        : 1d / columnPlans.Count;
+                    SetBoardColumnPixelWidth(plan.Column, plan.CurrentWidth + extra * share);
+                }
+            });
+        }
+
+        private static double GetPilotBoardViewportWidth(DataGrid pilotBoard)
+        {
+            try
+            {
+                var scrollViewer = FindVisualDescendant<ScrollViewer>(pilotBoard);
+                if (scrollViewer != null && scrollViewer.ViewportWidth > 0d)
+                {
+                    return Math.Max(0d, scrollViewer.ViewportWidth - 1d);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Visual tree may not be ready during early layout passes. Fall back below.
+            }
+
+            return Math.Max(0d, pilotBoard.ActualWidth - 1d);
+        }
+
+        private static T? FindVisualDescendant<T>(DependencyObject? root)
+            where T : DependencyObject
+        {
+            if (root == null)
+            {
+                return null;
+            }
+
+            var childCount = VisualTreeHelper.GetChildrenCount(root);
+            for (var index = 0; index < childCount; index++)
+            {
+                var child = VisualTreeHelper.GetChild(root, index);
+                if (child is T typed)
+                {
+                    return typed;
+                }
+
+                var nested = FindVisualDescendant<T>(child);
+                if (nested != null)
+                {
+                    return nested;
+                }
+            }
+
+            return null;
+        }
+
+        private static void SetBoardColumnPixelWidth(DataGridColumn column, double width)
+        {
+            if (column == null || double.IsNaN(width) || double.IsInfinity(width) || width <= 0d)
+            {
+                return;
+            }
+
+            var roundedWidth = Math.Round(width, 1);
+            if (Math.Abs(GetEffectiveBoardColumnWidth(column) - roundedWidth) < 0.5d &&
+                column.Width.UnitType == DataGridLengthUnitType.Pixel)
+            {
+                return;
+            }
+
+            column.Width = new DataGridLength(roundedWidth, DataGridLengthUnitType.Pixel);
+        }
+
+        private static double GetEffectiveBoardColumnWidth(DataGridColumn column)
+        {
+            if (column == null)
+            {
+                return 0d;
+            }
+
+            var width = column.ActualWidth;
+            if (double.IsNaN(width) || double.IsInfinity(width) || width <= 0)
+            {
+                width = column.Width.DisplayValue;
+            }
+
+            if (double.IsNaN(width) || double.IsInfinity(width) || width <= 0)
+            {
+                width = column.MinWidth;
+            }
+
+            return double.IsNaN(width) || double.IsInfinity(width) || width <= 0
+                ? 0d
+                : width;
+        }
+
+        private sealed record BoardColumnFitPlan(DataGridColumn Column, double MinimumWidth, double CurrentWidth);
+    }
+}

--- a/PitmastersGrill/Services/BoardColumnSettingsController.cs
+++ b/PitmastersGrill/Services/BoardColumnSettingsController.cs
@@ -1,0 +1,192 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class BoardColumnSettingsController
+    {
+        private readonly BoardColumnLayoutController _boardColumnLayoutController;
+        private readonly Action<AppSettings> _saveSettings;
+
+        public BoardColumnSettingsController(
+            BoardColumnLayoutController boardColumnLayoutController,
+            Action<AppSettings> saveSettings)
+        {
+            _boardColumnLayoutController = boardColumnLayoutController ?? throw new ArgumentNullException(nameof(boardColumnLayoutController));
+            _saveSettings = saveSettings ?? throw new ArgumentNullException(nameof(saveSettings));
+        }
+
+        public void InitializeBoardColumnLayoutUi(
+            Action<IEnumerable<BoardColumnLayoutSetting>, string> applyBoardColumnLayout,
+            params (string Key, DataGridColumn Column)[] columns)
+        {
+            if (applyBoardColumnLayout == null)
+            {
+                throw new ArgumentNullException(nameof(applyBoardColumnLayout));
+            }
+
+            _boardColumnLayoutController.InitializeColumns(columns);
+            _boardColumnLayoutController.ApplyColumnMinimumWidths();
+            _boardColumnLayoutController.BuildCanonicalBoardColumnLayout();
+            applyBoardColumnLayout(_boardColumnLayoutController.GetCanonicalBoardColumnLayout(), "Apply canonical default board layout");
+        }
+
+        public void ApplyBoardColumnSettingsToCheckBoxes(
+            AppSettings settings,
+            CheckBox showSigColumnCheckBox,
+            CheckBox showAllianceColumnCheckBox,
+            CheckBox showCorpColumnCheckBox,
+            CheckBox showKillsColumnCheckBox,
+            CheckBox showLossesColumnCheckBox,
+            CheckBox showAvgFleetSizeColumnCheckBox,
+            CheckBox showLastShipSeenColumnCheckBox,
+            CheckBox showLastSeenColumnCheckBox,
+            CheckBox showCynoHullSeenColumnCheckBox,
+            CheckBox? showCorpAllianceCountsCheckBox)
+        {
+            _boardColumnLayoutController.ApplyBoardColumnSettingsToCheckBoxes(
+                settings,
+                showSigColumnCheckBox,
+                showAllianceColumnCheckBox,
+                showCorpColumnCheckBox,
+                showKillsColumnCheckBox,
+                showLossesColumnCheckBox,
+                showAvgFleetSizeColumnCheckBox,
+                showLastShipSeenColumnCheckBox,
+                showLastSeenColumnCheckBox,
+                showCynoHullSeenColumnCheckBox,
+                showCorpAllianceCountsCheckBox);
+        }
+
+        public void SaveBoardColumnSettingsFromCheckBoxes(
+            AppSettings settings,
+            CheckBox showSigColumnCheckBox,
+            CheckBox showAllianceColumnCheckBox,
+            CheckBox showCorpColumnCheckBox,
+            CheckBox showKillsColumnCheckBox,
+            CheckBox showLossesColumnCheckBox,
+            CheckBox showAvgFleetSizeColumnCheckBox,
+            CheckBox showLastShipSeenColumnCheckBox,
+            CheckBox showLastSeenColumnCheckBox,
+            CheckBox showCynoHullSeenColumnCheckBox)
+        {
+            _boardColumnLayoutController.SaveBoardColumnSettingsFromCheckBoxes(
+                settings,
+                showSigColumnCheckBox,
+                showAllianceColumnCheckBox,
+                showCorpColumnCheckBox,
+                showKillsColumnCheckBox,
+                showLossesColumnCheckBox,
+                showAvgFleetSizeColumnCheckBox,
+                showLastShipSeenColumnCheckBox,
+                showLastSeenColumnCheckBox,
+                showCynoHullSeenColumnCheckBox);
+        }
+
+        public void ApplyBoardColumnVisibility(AppSettings settings)
+        {
+            _boardColumnLayoutController.ApplyBoardColumnVisibility(settings);
+        }
+
+        public void HandleBoardColumnVisibilityChanged(
+            bool isApplyingSettings,
+            AppSettings settings,
+            CheckBox showSigColumnCheckBox,
+            CheckBox showAllianceColumnCheckBox,
+            CheckBox showCorpColumnCheckBox,
+            CheckBox showKillsColumnCheckBox,
+            CheckBox showLossesColumnCheckBox,
+            CheckBox showAvgFleetSizeColumnCheckBox,
+            CheckBox showLastShipSeenColumnCheckBox,
+            CheckBox showLastSeenColumnCheckBox,
+            CheckBox showCynoHullSeenColumnCheckBox,
+            Action applyBoardColumnVisibility)
+        {
+            if (isApplyingSettings)
+            {
+                return;
+            }
+
+            SaveBoardColumnSettingsFromCheckBoxes(
+                settings,
+                showSigColumnCheckBox,
+                showAllianceColumnCheckBox,
+                showCorpColumnCheckBox,
+                showKillsColumnCheckBox,
+                showLossesColumnCheckBox,
+                showAvgFleetSizeColumnCheckBox,
+                showLastShipSeenColumnCheckBox,
+                showLastSeenColumnCheckBox,
+                showCynoHullSeenColumnCheckBox);
+            applyBoardColumnVisibility();
+            _saveSettings(settings);
+
+            AppLogger.UiInfo(
+                $"Board column visibility changed. sig={IsChecked(showSigColumnCheckBox)} alliance={IsChecked(showAllianceColumnCheckBox)} corp={IsChecked(showCorpColumnCheckBox)} kills={IsChecked(showKillsColumnCheckBox)} losses={IsChecked(showLossesColumnCheckBox)} avgFleet={IsChecked(showAvgFleetSizeColumnCheckBox)} lastShip={IsChecked(showLastShipSeenColumnCheckBox)} lastSeen={IsChecked(showLastSeenColumnCheckBox)} cynoHull={IsChecked(showCynoHullSeenColumnCheckBox)}");
+        }
+
+        public void HandleShowCorpAllianceCountsChanged(
+            bool isApplyingSettings,
+            AppSettings settings,
+            bool enabled,
+            Action recomputeCorpAllianceCounts)
+        {
+            if (isApplyingSettings)
+            {
+                return;
+            }
+
+            settings.ShowCorpAllianceCounts = enabled;
+            recomputeCorpAllianceCounts();
+            _saveSettings(settings);
+
+            AppLogger.UiInfo($"Corp/alliance board counts changed. enabled={settings.ShowCorpAllianceCounts}");
+        }
+
+        public void HandleShowAllBoardColumns(
+            AppSettings settings,
+            Action applyBoardColumnSettingsToCheckBoxes,
+            Action applyBoardColumnVisibility)
+        {
+            _boardColumnLayoutController.SetAllOptionalBoardColumnSettings(settings, true);
+            applyBoardColumnSettingsToCheckBoxes();
+            applyBoardColumnVisibility();
+            _saveSettings(settings);
+
+            AppLogger.UiInfo("Board column visibility reset to show all optional columns.");
+        }
+
+        public void HandleResetBoardColumns(
+            AppSettings settings,
+            Action applyBoardColumnSettingsToCheckBoxes,
+            Action applyBoardColumnVisibility)
+        {
+            _boardColumnLayoutController.SetAllOptionalBoardColumnSettings(settings, true);
+            applyBoardColumnSettingsToCheckBoxes();
+            applyBoardColumnVisibility();
+            _saveSettings(settings);
+
+            AppLogger.UiInfo("Board column visibility reset to defaults.");
+        }
+
+        public void HandleResetBoardLayout(
+            AppSettings settings,
+            Action<string> applyCanonicalBoardColumnLayout,
+            Action<string> saveCurrentBoardColumnLayout)
+        {
+            settings.BoardColumnLayout.Clear();
+            applyCanonicalBoardColumnLayout("Reset board layout to canonical defaults");
+            saveCurrentBoardColumnLayout("Reset layout");
+
+            AppLogger.UiInfo("Board column layout reset to canonical defaults.");
+        }
+
+        private static bool IsChecked(CheckBox checkBox)
+        {
+            return checkBox.IsChecked == true;
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Continues issue #54 with three focused MainWindow responsibility extraction passes.
- Extracts board column settings orchestration into BoardColumnSettingsController.
- Extracts board column layout persistence/autofit behavior into BoardColumnLayoutPersistenceController.
- Extracts board summary and Analysis tab projection into AnalysisTabPresenter.
- Adds unit coverage for the extracted controllers/presenter.

## Why
This continues the v1.4.0 MainWindow refactor without a broad rewrite. The goal is to keep shrinking MainWindow.xaml.cs by extracting cohesive, test-backed responsibilities while preserving runtime behavior.

## Validation
- dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"
  - Passed, 170/170.
- dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"
  - Passed.
- git --no-pager diff --check
  - Clean.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30 -BoardPopulationTimeoutSeconds 300
  - Passed.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke -ResponsivenessSeconds 30
  - Passed.
- Manual spot checks
  - Board column resize/reorder persistence and reset behavior passed.
  - Analysis inline zKill link behavior spot-checked.

## Notes
- MainWindow.xaml.cs is reduced from approximately 3970 lines at branch start to approximately 3513 lines after these passes.
- MainWindow.xaml remains under the 2,000-line release gate.
- This PR does not close #54; further extraction remains planned.
- Clipboard/hotkey/session-context and compact/window-shell seams were intentionally left untouched.

Refs #54
