### PR TITLE
Extract MainWindow shell mode coordinator

### DIFF
--- a/PitmastersGrill.Tests/Services/MainWindowShellModeCoordinatorTests.cs
+++ b/PitmastersGrill.Tests/Services/MainWindowShellModeCoordinatorTests.cs
@@ -1,0 +1,120 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System.Windows;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class MainWindowShellModeCoordinatorTests
+    {
+        [Fact]
+        public void BuildCompactModeTransition_WhenSwitchingToBoardMode_RequestsSaveRestoreHintAndPersistence()
+        {
+            var coordinator = new MainWindowShellModeCoordinator();
+
+            var result = coordinator.BuildCompactModeTransition(
+                compactMode: true,
+                previousCompactMode: false,
+                isApplyingSettings: false,
+                isRestoringWindowLayout: false,
+                currentSettingCompactEnabled: false,
+                currentSelectedTabIndex: 0);
+
+            Assert.True(result.ShouldSaveOutgoingLayout);
+            Assert.Equal(WindowLayoutMode.Normal, result.OutgoingLayoutMode);
+            Assert.True(result.ShouldRestoreIncomingLayout);
+            Assert.Equal(WindowLayoutMode.Board, result.IncomingLayoutMode);
+            Assert.True(result.ShouldSelectBoardTab);
+            Assert.Equal(1, result.TargetSelectedTabIndex);
+            Assert.True(result.ShouldCloseActiveDetailWindow);
+            Assert.True(result.ShouldPersistCompactModeSetting);
+            Assert.True(result.ShouldLogDisplayModeChanged);
+            Assert.True(result.ShouldShowBoardModeHint);
+            Assert.False(result.ShouldHideBoardModeHint);
+            Assert.Equal(Visibility.Collapsed, result.TopCommandVisibility);
+            Assert.Equal(Visibility.Collapsed, result.BoardStatusFooterVisibility);
+            Assert.Equal(new Thickness(1), result.MainContentMargin);
+        }
+
+        [Fact]
+        public void BuildCompactModeTransition_WhenApplyingSettings_DoesNotPersistSaveOrLog()
+        {
+            var coordinator = new MainWindowShellModeCoordinator();
+
+            var result = coordinator.BuildCompactModeTransition(
+                compactMode: false,
+                previousCompactMode: true,
+                isApplyingSettings: true,
+                isRestoringWindowLayout: false,
+                currentSettingCompactEnabled: true,
+                currentSelectedTabIndex: 1);
+
+            Assert.False(result.ShouldSaveOutgoingLayout);
+            Assert.False(result.ShouldRestoreIncomingLayout);
+            Assert.False(result.ShouldPersistCompactModeSetting);
+            Assert.False(result.ShouldLogDisplayModeChanged);
+            Assert.False(result.ShouldShowBoardModeHint);
+            Assert.True(result.ShouldHideBoardModeHint);
+            Assert.Equal(Visibility.Visible, result.TopCommandVisibility);
+            Assert.Equal(Visibility.Visible, result.BoardStatusFooterVisibility);
+        }
+
+        [Theory]
+        [InlineData(true, 1, Visibility.Collapsed)]
+        [InlineData(false, 0, Visibility.Collapsed)]
+        [InlineData(false, 2, Visibility.Visible)]
+        public void BuildBoardStatusFooterVisibility_MatchesBoardAndAnalysisRules(
+            bool compactMode,
+            int selectedTabIndex,
+            Visibility expectedVisibility)
+        {
+            var coordinator = new MainWindowShellModeCoordinator();
+
+            var result = coordinator.BuildBoardStatusFooterVisibility(compactMode, selectedTabIndex);
+
+            Assert.Equal(expectedVisibility, result);
+        }
+
+        [Fact]
+        public void BuildMinimumWindowSize_ForBoardMode_UsesMeasurementsAndFallbacks()
+        {
+            var coordinator = new MainWindowShellModeCoordinator();
+
+            var result = coordinator.BuildMinimumWindowSize(
+                compactMode: true,
+                normalModeMinimumWindowWidth: 420,
+                normalModeMinimumWindowHeight: 300,
+                boardModeMinimumWindowWidth: 420,
+                contentMarginHeight: 2,
+                commandStripHeight: 0,
+                tabHeaderHeight: 10,
+                boardColumnHeaderHeight: 0,
+                boardRowHeight: 0,
+                boardFontSize: 12,
+                boardModeFallbackCommandStripHeight: 38,
+                boardModeFallbackTabHeaderHeight: 32,
+                boardModeFallbackColumnHeaderHeight: 28,
+                boardModeFallbackFooterPaddingHeight: 18,
+                boardModeFallbackRowVerticalPadding: 16);
+
+            Assert.Equal(420, result.MinWidth);
+            Assert.Equal(146, result.MinHeight);
+        }
+
+        [Theory]
+        [InlineData(WindowState.Normal, "[]", "Maximize PMG")]
+        [InlineData(WindowState.Maximized, "O", "Restore PMG")]
+        public void BuildMaximizeRestoreWindowButtonState_ReflectsWindowState(
+            WindowState windowState,
+            string expectedContent,
+            string expectedToolTip)
+        {
+            var coordinator = new MainWindowShellModeCoordinator();
+
+            var result = coordinator.BuildMaximizeRestoreWindowButtonState(windowState);
+
+            Assert.Equal(expectedContent, result.Content);
+            Assert.Equal(expectedToolTip, result.ToolTip);
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -66,6 +66,7 @@ namespace PitmastersGrill
         private readonly SettingsTabController _settingsTabController;
         private readonly AnalysisTabController _analysisTabController;
         private readonly AnalysisTabPresenter _analysisTabPresenter = null!;
+        private readonly MainWindowShellModeCoordinator _mainWindowShellModeCoordinator;
         private readonly WindowLayoutController _windowLayoutController;
         private readonly BoardPopulationStatusController _boardPopulationStatusController;
         private readonly BoardPopulationRowProcessor _boardPopulationRowProcessor;
@@ -149,6 +150,7 @@ namespace PitmastersGrill
                 _boardDisplaySettingsController,
                 settings => _mainWindowAppearanceController.SaveSettings(settings));
             _analysisTabController = new AnalysisTabController();
+            _mainWindowShellModeCoordinator = new MainWindowShellModeCoordinator();
             _windowLayoutController = new WindowLayoutController();
             _boardPopulationStatusController = new BoardPopulationStatusController();
 
@@ -504,7 +506,83 @@ namespace PitmastersGrill
             ApplyCompactModeUi();
         }
 
-        private void ApplyCompactModeUi() { if (CompactModeToggleButton == null || MainContentGrid == null || TopCommandGrid == null || MainTabControl == null || BoardStatusFooter == null) { return; } var compact = CompactModeToggleButton.IsChecked == true; var previousCompactMode = _lastAppliedCompactMode; var displayModeChanged = !_isApplyingSettings && !_isRestoringWindowLayout && previousCompactMode.HasValue && previousCompactMode.Value != compact; if (displayModeChanged && previousCompactMode.HasValue) { var wasBoardMode = previousCompactMode.GetValueOrDefault(); var outgoingLayoutMode = wasBoardMode ? WindowLayoutMode.Board : WindowLayoutMode.Normal; SaveWindowLayoutToSettings($"Before display mode change to {(compact ? "Board" : "Normal")}", outgoingLayoutMode); } _lastAppliedCompactMode = compact; if (compact) { MainTabControl.SelectedIndex = 1; CloseActiveDetailWindow(); } TopCommandGrid.Visibility = compact ? Visibility.Collapsed : Visibility.Visible; TopCommandGrid.Margin = new Thickness(0, 0, 0, 6); BoardStatusFooter.Padding = new Thickness(8, 5, 8, 5); MainContentGrid.Margin = compact ? new Thickness(1) : new Thickness(12); MainTabControl.BorderThickness = compact ? new Thickness(0) : new Thickness(1); MainTabControl.Margin = compact ? new Thickness(0) : new Thickness(0); if (!_isApplyingSettings && _appSettings.CompactModeEnabled != compact) { _appSettings.CompactModeEnabled = compact; _mainWindowAppearanceController.SaveSettings(_appSettings); } if (!_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { AppLogger.UiInfo($"Display mode changed.\nboardMode={compact}"); } if (compact && !_isApplyingSettings && (!previousCompactMode.HasValue || previousCompactMode.Value != compact)) { ShowBoardModeHint(); } else if (!compact) { HideBoardModeHint(); } UpdateWindowMinimumSize(); if (displayModeChanged) { RestoreWindowLayoutFromSettings(compact ? WindowLayoutMode.Board : WindowLayoutMode.Normal); } UpdateBoardFooterVisibility(); UpdateBoardSummaryBanner(); UpdateAnalysisTab(); }
+        private void ApplyCompactModeUi()
+        {
+            if (CompactModeToggleButton == null ||
+                MainContentGrid == null ||
+                TopCommandGrid == null ||
+                MainTabControl == null ||
+                BoardStatusFooter == null)
+            {
+                return;
+            }
+
+            var transition = _mainWindowShellModeCoordinator.BuildCompactModeTransition(
+                CompactModeToggleButton.IsChecked == true,
+                _lastAppliedCompactMode,
+                _isApplyingSettings,
+                _isRestoringWindowLayout,
+                _appSettings.CompactModeEnabled,
+                MainTabControl.SelectedIndex);
+
+            if (transition.ShouldSaveOutgoingLayout)
+            {
+                var outgoingLayoutMode = transition.OutgoingLayoutMode;
+                SaveWindowLayoutToSettings(
+                    $"Before display mode change to {(transition.CompactMode ? "Board" : "Normal")}",
+                    outgoingLayoutMode);
+            }
+
+            _lastAppliedCompactMode = transition.CompactMode;
+
+            if (transition.ShouldSelectBoardTab)
+            {
+                MainTabControl.SelectedIndex = transition.TargetSelectedTabIndex;
+            }
+
+            if (transition.ShouldCloseActiveDetailWindow)
+            {
+                CloseActiveDetailWindow();
+            }
+
+            TopCommandGrid.Visibility = transition.TopCommandVisibility;
+            TopCommandGrid.Margin = new Thickness(0, 0, 0, 6);
+            BoardStatusFooter.Padding = transition.BoardStatusFooterPadding;
+            MainContentGrid.Margin = transition.MainContentMargin;
+            MainTabControl.BorderThickness = transition.MainTabBorderThickness;
+            MainTabControl.Margin = transition.MainTabMargin;
+
+            if (transition.ShouldPersistCompactModeSetting)
+            {
+                _appSettings.CompactModeEnabled = transition.CompactMode;
+                _mainWindowAppearanceController.SaveSettings(_appSettings);
+            }
+
+            if (transition.ShouldLogDisplayModeChanged)
+            {
+                AppLogger.UiInfo($"Display mode changed.\nboardMode={transition.CompactMode}");
+            }
+
+            if (transition.ShouldShowBoardModeHint)
+            {
+                ShowBoardModeHint();
+            }
+            else if (transition.ShouldHideBoardModeHint)
+            {
+                HideBoardModeHint();
+            }
+
+            UpdateWindowMinimumSize();
+
+            if (transition.ShouldRestoreIncomingLayout)
+            {
+                RestoreWindowLayoutFromSettings(transition.IncomingLayoutMode);
+            }
+
+            BoardStatusFooter.Visibility = transition.BoardStatusFooterVisibility;
+            UpdateBoardSummaryBanner();
+            UpdateAnalysisTab();
+        }
         private void MainTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (!ReferenceEquals(sender, MainTabControl))
@@ -531,11 +609,9 @@ namespace PitmastersGrill
                 return;
             }
 
-            var boardMode = CompactModeToggleButton.IsChecked == true;
-            var analysisTabSelected = MainTabControl.SelectedIndex == 0;
-            BoardStatusFooter.Visibility = boardMode || analysisTabSelected
-                ? Visibility.Collapsed
-                : Visibility.Visible;
+            BoardStatusFooter.Visibility = _mainWindowShellModeCoordinator.BuildBoardStatusFooterVisibility(
+                CompactModeToggleButton.IsChecked == true,
+                MainTabControl.SelectedIndex);
         }
 
         private void ToggleCompactModeFromHotkey()
@@ -579,32 +655,25 @@ namespace PitmastersGrill
 
         private void UpdateWindowMinimumSize()
         {
-            if (CompactModeToggleButton?.IsChecked == true)
-            {
-                MinWidth = BoardModeMinimumWindowWidth;
-                MinHeight = GetBoardModeMinimumWindowHeight();
-                return;
-            }
+            var minimumSize = _mainWindowShellModeCoordinator.BuildMinimumWindowSize(
+                CompactModeToggleButton?.IsChecked == true,
+                NormalModeMinimumWindowWidth,
+                NormalModeMinimumWindowHeight,
+                BoardModeMinimumWindowWidth,
+                MainContentGrid?.Margin.Top + MainContentGrid?.Margin.Bottom ?? 0,
+                TopCommandGrid?.ActualHeight ?? 0,
+                GetTabHeaderHeight(),
+                GetBoardColumnHeaderHeight(),
+                GetBoardRowHeight(),
+                PilotBoard?.FontSize ?? 12,
+                BoardModeFallbackCommandStripHeight,
+                BoardModeFallbackTabHeaderHeight,
+                BoardModeFallbackColumnHeaderHeight,
+                BoardModeFallbackFooterPaddingHeight,
+                BoardModeFallbackRowVerticalPadding);
 
-            MinWidth = NormalModeMinimumWindowWidth;
-            MinHeight = NormalModeMinimumWindowHeight;
-        }
-
-        private double GetBoardModeMinimumWindowHeight()
-        {
-            var contentMarginHeight = MainContentGrid?.Margin.Top + MainContentGrid?.Margin.Bottom ?? 0;
-            var commandStripHeight = Math.Max(TopCommandGrid?.ActualHeight ?? 0, BoardModeFallbackCommandStripHeight);
-            var tabHeaderHeight = Math.Max(GetTabHeaderHeight(), BoardModeFallbackTabHeaderHeight);
-            var boardColumnHeaderHeight = Math.Max(GetBoardColumnHeaderHeight(), BoardModeFallbackColumnHeaderHeight);
-            var boardRowHeight = Math.Max(GetBoardRowHeight(), Math.Ceiling((PilotBoard?.FontSize ?? 12) + BoardModeFallbackRowVerticalPadding));
-
-            return Math.Ceiling(
-                contentMarginHeight +
-                commandStripHeight +
-                tabHeaderHeight +
-                boardColumnHeaderHeight +
-                boardRowHeight +
-                BoardModeFallbackFooterPaddingHeight);
+            MinWidth = minimumSize.MinWidth;
+            MinHeight = minimumSize.MinHeight;
         }
 
         private double GetTabHeaderHeight()
@@ -650,9 +719,9 @@ namespace PitmastersGrill
                 return;
             }
 
-            var isMaximized = WindowState == WindowState.Maximized;
-            MaximizeRestoreWindowButton.Content = isMaximized ? "O" : "[]";
-            MaximizeRestoreWindowButton.ToolTip = isMaximized ? "Restore PMG" : "Maximize PMG";
+            var buttonState = _mainWindowShellModeCoordinator.BuildMaximizeRestoreWindowButtonState(WindowState);
+            MaximizeRestoreWindowButton.Content = buttonState.Content;
+            MaximizeRestoreWindowButton.ToolTip = buttonState.ToolTip;
         }
 
         private void TrackCurrentNormalWindowBounds(string reason)

--- a/PitmastersGrill/Services/MainWindowShellModeCoordinator.cs
+++ b/PitmastersGrill/Services/MainWindowShellModeCoordinator.cs
@@ -1,0 +1,124 @@
+using PitmastersGrill.Models;
+using System.Windows;
+
+namespace PitmastersGrill.Services
+{
+    public sealed record MainWindowShellModeTransition(
+        bool CompactMode,
+        bool? PreviousCompactMode,
+        bool ShouldSaveOutgoingLayout,
+        WindowLayoutMode OutgoingLayoutMode,
+        bool ShouldRestoreIncomingLayout,
+        WindowLayoutMode IncomingLayoutMode,
+        bool ShouldSelectBoardTab,
+        int TargetSelectedTabIndex,
+        bool ShouldCloseActiveDetailWindow,
+        bool ShouldPersistCompactModeSetting,
+        bool ShouldLogDisplayModeChanged,
+        bool ShouldShowBoardModeHint,
+        bool ShouldHideBoardModeHint,
+        Thickness MainContentMargin,
+        Thickness MainTabBorderThickness,
+        Thickness MainTabMargin,
+        Thickness BoardStatusFooterPadding,
+        Visibility TopCommandVisibility,
+        Visibility BoardStatusFooterVisibility);
+
+    public sealed record MainWindowMinimumSize(double MinWidth, double MinHeight);
+
+    public sealed record MaximizeRestoreWindowButtonState(string Content, string ToolTip);
+
+    public sealed class MainWindowShellModeCoordinator
+    {
+        public MainWindowShellModeTransition BuildCompactModeTransition(
+            bool compactMode,
+            bool? previousCompactMode,
+            bool isApplyingSettings,
+            bool isRestoringWindowLayout,
+            bool currentSettingCompactEnabled,
+            int currentSelectedTabIndex)
+        {
+            var displayModeChanged = !isApplyingSettings &&
+                                     !isRestoringWindowLayout &&
+                                     previousCompactMode.HasValue &&
+                                     previousCompactMode.Value != compactMode;
+            var shouldLogDisplayModeChanged = !isApplyingSettings &&
+                                              (!previousCompactMode.HasValue || previousCompactMode.Value != compactMode);
+            var targetSelectedTabIndex = compactMode ? 1 : currentSelectedTabIndex;
+
+            return new MainWindowShellModeTransition(
+                CompactMode: compactMode,
+                PreviousCompactMode: previousCompactMode,
+                ShouldSaveOutgoingLayout: displayModeChanged && previousCompactMode.HasValue,
+                OutgoingLayoutMode: previousCompactMode == true ? WindowLayoutMode.Board : WindowLayoutMode.Normal,
+                ShouldRestoreIncomingLayout: displayModeChanged,
+                IncomingLayoutMode: compactMode ? WindowLayoutMode.Board : WindowLayoutMode.Normal,
+                ShouldSelectBoardTab: compactMode,
+                TargetSelectedTabIndex: targetSelectedTabIndex,
+                ShouldCloseActiveDetailWindow: compactMode,
+                ShouldPersistCompactModeSetting: !isApplyingSettings && currentSettingCompactEnabled != compactMode,
+                ShouldLogDisplayModeChanged: shouldLogDisplayModeChanged,
+                ShouldShowBoardModeHint: compactMode && shouldLogDisplayModeChanged,
+                ShouldHideBoardModeHint: !compactMode,
+                MainContentMargin: compactMode ? new Thickness(1) : new Thickness(12),
+                MainTabBorderThickness: compactMode ? new Thickness(0) : new Thickness(1),
+                MainTabMargin: new Thickness(0),
+                BoardStatusFooterPadding: new Thickness(8, 5, 8, 5),
+                TopCommandVisibility: compactMode ? Visibility.Collapsed : Visibility.Visible,
+                BoardStatusFooterVisibility: BuildBoardStatusFooterVisibility(compactMode, targetSelectedTabIndex));
+        }
+
+        public Visibility BuildBoardStatusFooterVisibility(bool compactMode, int selectedTabIndex)
+        {
+            return compactMode || selectedTabIndex == 0
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        }
+
+        public MainWindowMinimumSize BuildMinimumWindowSize(
+            bool compactMode,
+            double normalModeMinimumWindowWidth,
+            double normalModeMinimumWindowHeight,
+            double boardModeMinimumWindowWidth,
+            double contentMarginHeight,
+            double commandStripHeight,
+            double tabHeaderHeight,
+            double boardColumnHeaderHeight,
+            double boardRowHeight,
+            double boardFontSize,
+            double boardModeFallbackCommandStripHeight,
+            double boardModeFallbackTabHeaderHeight,
+            double boardModeFallbackColumnHeaderHeight,
+            double boardModeFallbackFooterPaddingHeight,
+            double boardModeFallbackRowVerticalPadding)
+        {
+            if (!compactMode)
+            {
+                return new MainWindowMinimumSize(normalModeMinimumWindowWidth, normalModeMinimumWindowHeight);
+            }
+
+            var effectiveCommandStripHeight = Math.Max(commandStripHeight, boardModeFallbackCommandStripHeight);
+            var effectiveTabHeaderHeight = Math.Max(tabHeaderHeight, boardModeFallbackTabHeaderHeight);
+            var effectiveBoardColumnHeaderHeight = Math.Max(boardColumnHeaderHeight, boardModeFallbackColumnHeaderHeight);
+            var effectiveBoardRowHeight = Math.Max(boardRowHeight, Math.Ceiling(boardFontSize + boardModeFallbackRowVerticalPadding));
+
+            return new MainWindowMinimumSize(
+                boardModeMinimumWindowWidth,
+                Math.Ceiling(
+                    contentMarginHeight +
+                    effectiveCommandStripHeight +
+                    effectiveTabHeaderHeight +
+                    effectiveBoardColumnHeaderHeight +
+                    effectiveBoardRowHeight +
+                    boardModeFallbackFooterPaddingHeight));
+        }
+
+        public MaximizeRestoreWindowButtonState BuildMaximizeRestoreWindowButtonState(WindowState windowState)
+        {
+            var isMaximized = windowState == WindowState.Maximized;
+            return new MaximizeRestoreWindowButtonState(
+                isMaximized ? "O" : "[]",
+                isMaximized ? "Restore PMG" : "Maximize PMG");
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Continues issue #54 with one focused MainWindow shell-mode extraction.
- Extracts compact/board-mode decision logic into MainWindowShellModeCoordinator.
- Moves board-footer visibility rules, board-mode minimum-size calculation, and maximize/restore button state into a test-backed coordinator.
- Leaves WPF-bound callbacks, layout save/restore, board-mode hint timer wiring, clipboard/hotkey/session-context, and board population in MainWindow.

## Why
This improves maintainability and test coverage around compact/board-mode shell behavior without touching higher-risk input, clipboard, hotkey, session-context, or board-population flows.

## Validation
- dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"
  - Passed, 178/178.
- dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"
  - Passed.
- git --no-pager diff --check
  - Clean.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30 -BoardPopulationTimeoutSeconds 300
  - Passed.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke -ResponsivenessSeconds 30
  - Passed.
- Manual shell spot checks
  - Compact mode toggle on/off passed.
  - Board tab selection on entering board mode passed.
  - Board-mode hint overlay behavior passed.
  - Footer hide/show behavior across Analysis, compact mode, and normal mode passed.
  - Maximize/restore glyph and tooltip behavior passed.
  - Normal/compact layout restore after restart passed.

## Notes
- This is a maintainability/testability pass, not a line-count reduction pass.
- MainWindow.xaml.cs line count increased because dense shell-mode boundary code was expanded into readable WPF wiring while decision logic moved into the coordinator.
- This PR does not close #54; further extraction remains planned.
- Clipboard/hotkey/session-context and board-population logic were intentionally left untouched.

Refs #54
