### PR TITLE
Extract detail window lifecycle decisions

### DIFF
--- a/PitmastersGrill.Tests/Services/DetailPaneControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/DetailPaneControllerTests.cs
@@ -1,0 +1,115 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using PitmastersGrill.Services;
+using System;
+using System.IO;
+using System.Windows;
+using System.Reflection;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class DetailPaneControllerTests : IDisposable
+    {
+        private readonly string _tempDirectory;
+
+        public DetailPaneControllerTests()
+        {
+            _tempDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "PitmastersGrill.Tests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDirectory);
+        }
+
+        [Fact]
+        public void GetSelectedOrDisplayedDetailRow_ReturnsSelectedRowFirst()
+        {
+            var controller = CreateController();
+            var selectedRow = new PilotBoardRow { CharacterName = "Aura" };
+            var displayedRow = new PilotBoardRow { CharacterName = "Chribba" };
+
+            var result = controller.GetSelectedOrDisplayedDetailRow(
+                selectedRow,
+                Visibility.Visible,
+                "Chribba",
+                new[] { selectedRow, displayedRow });
+
+            Assert.Same(selectedRow, result);
+        }
+
+        [Fact]
+        public void GetSelectedOrDisplayedDetailRow_UsesDisplayedCharacterWhenVisible()
+        {
+            var controller = CreateController();
+            var row = new PilotBoardRow { CharacterName = "Chribba" };
+
+            var result = controller.GetSelectedOrDisplayedDetailRow(
+                null,
+                Visibility.Visible,
+                "  chribba  ",
+                new[] { row });
+
+            Assert.Same(row, result);
+        }
+
+        [Fact]
+        public void IsRowDisplayedInDetailPane_ReturnsTrueWhenDisplayedCharacterMatches()
+        {
+            var controller = CreateController();
+            var row = new PilotBoardRow { CharacterName = "Aura" };
+
+            var result = controller.IsRowDisplayedInDetailPane(
+                row,
+                null,
+                Visibility.Visible,
+                "Aura");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void SaveCurrentNotesAndTags_UpdatesSelectedRowWhenCharacterMatches()
+        {
+            var controller = CreateController();
+            var row = new PilotBoardRow { CharacterName = "Aura" };
+            SetActiveDetailCharacter(controller, row.CharacterName);
+
+            controller.SaveCurrentNotesAndTags("notes", knownCynoOverride: true, baitOverride: true, row);
+
+            Assert.True(row.KnownCynoOverride);
+            Assert.True(row.BaitOverride);
+        }
+
+        private DetailPaneController CreateController()
+        {
+            return new DetailPaneController(
+                new NotesRepository(Path.Combine(_tempDirectory, "notes.json")),
+                new PilotBoardRowDetailFormatter(new BoardPopulationRetryPolicy()));
+        }
+
+        private static void SetActiveDetailCharacter(DetailPaneController controller, string characterName)
+        {
+            var field = typeof(DetailPaneController).GetField(
+                "_activeDetailCharacterName",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            Assert.NotNull(field);
+            field!.SetValue(controller, characterName);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_tempDirectory))
+                {
+                    Directory.Delete(_tempDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/PilotDetailWindowLifecycleControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/PilotDetailWindowLifecycleControllerTests.cs
@@ -1,0 +1,62 @@
+using PitmastersGrill.Services;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class PilotDetailWindowLifecycleControllerTests
+    {
+        [Fact]
+        public void DecideOpenAction_WhenNoActiveWindow_ReturnsCreateNew()
+        {
+            var controller = new PilotDetailWindowLifecycleController();
+
+            var result = controller.DecideOpenAction("Aura");
+
+            Assert.Equal(PilotDetailWindowOpenAction.CreateNew, result);
+        }
+
+        [Fact]
+        public void DecideOpenAction_WhenSameCharacterAlreadyOpen_ReturnsActivateExisting()
+        {
+            var controller = new PilotDetailWindowLifecycleController();
+            controller.MarkWindowOpened("Aura");
+
+            var result = controller.DecideOpenAction("aura");
+
+            Assert.Equal(PilotDetailWindowOpenAction.ActivateExisting, result);
+        }
+
+        [Fact]
+        public void DecideOpenAction_WhenDifferentCharacterAlreadyOpen_ReturnsReplaceExisting()
+        {
+            var controller = new PilotDetailWindowLifecycleController();
+            controller.MarkWindowOpened("Aura");
+
+            var result = controller.DecideOpenAction("Chribba");
+
+            Assert.Equal(PilotDetailWindowOpenAction.ReplaceExisting, result);
+        }
+
+        [Fact]
+        public void ShouldRefreshActiveWindow_MatchesActiveCharacter()
+        {
+            var controller = new PilotDetailWindowLifecycleController();
+            controller.MarkWindowOpened("Aura");
+
+            Assert.True(controller.ShouldRefreshActiveWindow("Aura"));
+            Assert.False(controller.ShouldRefreshActiveWindow("Chribba"));
+        }
+
+        [Fact]
+        public void ClearActiveWindow_RemovesTrackedState()
+        {
+            var controller = new PilotDetailWindowLifecycleController();
+            controller.MarkWindowOpened("Aura");
+
+            controller.ClearActiveWindow();
+
+            Assert.False(controller.HasActiveWindow);
+            Assert.Equal(string.Empty, controller.ActiveCharacterName);
+        }
+    }
+}

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -92,6 +92,7 @@ namespace PitmastersGrill
         private readonly DiagnosticsCacheMaintenanceController _diagnosticsCacheMaintenanceController = null!;
         private readonly PilotDetailActionsPresenter _pilotDetailActionsPresenter;
         private readonly PilotDetailWindowPlacementController _pilotDetailWindowPlacementController;
+        private readonly PilotDetailWindowLifecycleController _pilotDetailWindowLifecycleController;
         private readonly BoardPopulationTimingMarkerTracker _boardPopulationTimingMarkerTracker;
         private readonly IgnoreAllianceCoordinator _ignoreAllianceCoordinator;
         private readonly IgnoreAllianceBoardController _ignoreAllianceBoardController;
@@ -161,6 +162,7 @@ namespace PitmastersGrill
             _boardPopulationStatusController = new BoardPopulationStatusController();
             _pilotDetailActionsPresenter = new PilotDetailActionsPresenter();
             _pilotDetailWindowPlacementController = new PilotDetailWindowPlacementController();
+            _pilotDetailWindowLifecycleController = new PilotDetailWindowLifecycleController();
 
             _isApplyingSettings = true;
             AppLogger.UiInfo("MainWindow InitializeComponent begin.");
@@ -1841,7 +1843,7 @@ namespace PitmastersGrill
             RecomputeCorpAllianceCounts();
 
             if (_activePilotDetailWindow != null &&
-                string.Equals(_activePilotDetailWindow.CharacterName, row.CharacterName, StringComparison.OrdinalIgnoreCase))
+                _pilotDetailWindowLifecycleController.ShouldRefreshActiveWindow(row.CharacterName))
             {
                 _activePilotDetailWindow.RefreshRow();
             }
@@ -2455,14 +2457,15 @@ namespace PitmastersGrill
 
         private void OpenDetailsWindow(PilotBoardRow row)
         {
-            if (_activePilotDetailWindow != null)
+            var action = _pilotDetailWindowLifecycleController.DecideOpenAction(row.CharacterName);
+            if (action == PilotDetailWindowOpenAction.ActivateExisting)
             {
-                if (string.Equals(_activePilotDetailWindow.CharacterName, row.CharacterName, StringComparison.OrdinalIgnoreCase))
-                {
-                    _activePilotDetailWindow.Activate();
-                    return;
-                }
+                _activePilotDetailWindow?.Activate();
+                return;
+            }
 
+            if (action == PilotDetailWindowOpenAction.ReplaceExisting)
+            {
                 CloseActiveDetailWindow();
             }
 
@@ -2480,6 +2483,7 @@ namespace PitmastersGrill
             _activePilotDetailWindow.Topmost = Topmost;
             PositionDetailWindow(_activePilotDetailWindow);
             _activePilotDetailWindow.Closed += ActivePilotDetailWindow_Closed;
+            _pilotDetailWindowLifecycleController.MarkWindowOpened(row.CharacterName);
             _activePilotDetailWindow.Show();
             AppLogger.UiInfo($"Details window opened. character='{row.CharacterName}'");
         }
@@ -2547,6 +2551,8 @@ namespace PitmastersGrill
                 _activePilotDetailWindow.Closed -= ActivePilotDetailWindow_Closed;
                 _activePilotDetailWindow = null;
             }
+
+            _pilotDetailWindowLifecycleController.ClearActiveWindow();
         }
 
         private void CloseActiveDetailWindow()
@@ -2560,6 +2566,7 @@ namespace PitmastersGrill
             _activePilotDetailWindow = null;
             window.Closed -= ActivePilotDetailWindow_Closed;
             window.SaveCurrentState();
+            _pilotDetailWindowLifecycleController.ClearActiveWindow();
             window.Close();
         }
 
@@ -2711,46 +2718,20 @@ namespace PitmastersGrill
 
         private PilotBoardRow? GetSelectedOrDisplayedDetailRow()
         {
-            if (PilotBoard.SelectedItem is PilotBoardRow selectedRow)
-            {
-                return selectedRow;
-            }
-
-            if (DetailPane.Visibility != Visibility.Visible)
-            {
-                return null;
-            }
-
-            var displayedCharacterName = SelectedCharacterText.Text;
-
-            if (string.IsNullOrWhiteSpace(displayedCharacterName))
-            {
-                return null;
-            }
-
-            return _currentRows.FirstOrDefault(row =>
-                string.Equals(
-                    row.CharacterName,
-                    displayedCharacterName.Trim(),
-                    StringComparison.OrdinalIgnoreCase));
+            return _detailPaneController.GetSelectedOrDisplayedDetailRow(
+                PilotBoard.SelectedItem as PilotBoardRow,
+                DetailPane.Visibility,
+                SelectedCharacterText.Text,
+                _currentRows);
         }
 
         private bool IsRowDisplayedInDetailPane(PilotBoardRow row)
         {
-            if (row == null || DetailPane.Visibility != Visibility.Visible)
-            {
-                return false;
-            }
-
-            if (PilotBoard.SelectedItem is PilotBoardRow selectedRow && ReferenceEquals(selectedRow, row))
-            {
-                return true;
-            }
-
-            return string.Equals(
-                SelectedCharacterText.Text,
-                row.CharacterName,
-                StringComparison.OrdinalIgnoreCase);
+            return _detailPaneController.IsRowDisplayedInDetailPane(
+                row,
+                PilotBoard.SelectedItem as PilotBoardRow,
+                DetailPane.Visibility,
+                SelectedCharacterText.Text);
         }
 
         private void UpdateIgnoreAllianceButtonState(PilotBoardRow? row)

--- a/PitmastersGrill/Services/DetailPaneController.cs
+++ b/PitmastersGrill/Services/DetailPaneController.cs
@@ -1,6 +1,8 @@
-﻿using PitmastersGrill.Models;
+using PitmastersGrill.Models;
 using PitmastersGrill.Persistence;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -22,6 +24,8 @@ namespace PitmastersGrill.Services
         }
 
         public bool IsApplyingState { get; private set; }
+        public bool HasActiveDetail => !string.IsNullOrWhiteSpace(_activeDetailCharacterName);
+        public string ActiveDetailCharacterName => _activeDetailCharacterName;
 
         public void RefreshDetailPaneIfSelected(
             PilotBoardRow row,
@@ -196,6 +200,53 @@ namespace PitmastersGrill.Services
 
             selectedRow.BaitOverride = baitOverride;
             return true;
+        }
+
+        public PilotBoardRow? GetSelectedOrDisplayedDetailRow(
+            PilotBoardRow? selectedRow,
+            Visibility detailPaneVisibility,
+            string? displayedCharacterName,
+            IReadOnlyCollection<PilotBoardRow> currentRows)
+        {
+            if (selectedRow != null)
+            {
+                return selectedRow;
+            }
+
+            if (detailPaneVisibility != Visibility.Visible ||
+                string.IsNullOrWhiteSpace(displayedCharacterName) ||
+                currentRows == null)
+            {
+                return null;
+            }
+
+            return currentRows.FirstOrDefault(row =>
+                string.Equals(
+                    row.CharacterName,
+                    displayedCharacterName.Trim(),
+                    StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool IsRowDisplayedInDetailPane(
+            PilotBoardRow? row,
+            PilotBoardRow? selectedRow,
+            Visibility detailPaneVisibility,
+            string? displayedCharacterName)
+        {
+            if (row == null || detailPaneVisibility != Visibility.Visible)
+            {
+                return false;
+            }
+
+            if (selectedRow != null && ReferenceEquals(selectedRow, row))
+            {
+                return true;
+            }
+
+            return string.Equals(
+                displayedCharacterName,
+                row.CharacterName,
+                StringComparison.OrdinalIgnoreCase);
         }
 
         private void ApplyDetailPaneText(

--- a/PitmastersGrill/Services/PilotDetailWindowLifecycleController.cs
+++ b/PitmastersGrill/Services/PilotDetailWindowLifecycleController.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace PitmastersGrill.Services
+{
+    public enum PilotDetailWindowOpenAction
+    {
+        None = 0,
+        CreateNew,
+        ActivateExisting,
+        ReplaceExisting
+    }
+
+    public sealed class PilotDetailWindowLifecycleController
+    {
+        private string _activeCharacterName = string.Empty;
+
+        public bool HasActiveWindow => !string.IsNullOrWhiteSpace(_activeCharacterName);
+        public string ActiveCharacterName => _activeCharacterName;
+
+        public PilotDetailWindowOpenAction DecideOpenAction(string targetCharacterName)
+        {
+            if (string.IsNullOrWhiteSpace(targetCharacterName))
+            {
+                return PilotDetailWindowOpenAction.None;
+            }
+
+            if (!HasActiveWindow)
+            {
+                return PilotDetailWindowOpenAction.CreateNew;
+            }
+
+            return string.Equals(_activeCharacterName, targetCharacterName, StringComparison.OrdinalIgnoreCase)
+                ? PilotDetailWindowOpenAction.ActivateExisting
+                : PilotDetailWindowOpenAction.ReplaceExisting;
+        }
+
+        public void MarkWindowOpened(string characterName)
+        {
+            _activeCharacterName = characterName ?? string.Empty;
+        }
+
+        public bool ShouldRefreshActiveWindow(string rowCharacterName)
+        {
+            return HasActiveWindow &&
+                   !string.IsNullOrWhiteSpace(rowCharacterName) &&
+                   string.Equals(_activeCharacterName, rowCharacterName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void ClearActiveWindow()
+        {
+            _activeCharacterName = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Continues issue #54 with a focused detail-pane/detail-window lifecycle extraction.
- Moves selected-or-displayed detail-row resolution into DetailPaneController.
- Moves displayed-row matching checks into DetailPaneController.
- Adds PilotDetailWindowLifecycleController for create/activate/replace detail-window decisions.
- Adds tests for detail-row resolution and detail-window lifecycle decisions.

## Why
This reduces MainWindow.xaml.cs responsibility while keeping actual WPF detail-window creation, positioning, theme/topmost setup, and event wiring in MainWindow where they still belong.

## Validation
- dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"
  - Passed, 206/206.
- dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"
  - Passed.
- git --no-pager diff --check
  - Clean.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30 -BoardPopulationTimeoutSeconds 300
  - Passed.
- .\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke -ResponsivenessSeconds 30
  - Passed.
- Manual detail-window checks
  - Detail window open behavior passed.
  - Same-row activate behavior passed.
  - Different-row replace behavior passed.
  - Detail pane notes-state behavior passed.
  - Normal close/restart after opening a detail window passed.

## Notes
- MainWindow.xaml.cs was reduced from approximately 3429 lines to approximately 3410 lines on the current base.
- This PR does not close #54; further extraction remains planned.
- Notes/tags/known-cyno/bait override orchestration, board population orchestration, native listener/hotkey lifecycle, and constructor/lifecycle cleanup remain deferred.

Refs #54
