### PR TITLE
Refactor MainWindow support and lifecycle surfaces for 1.4.0

### DIFF
--- a/PitmastersGrill.Tests/Services/BoardPopulationSurfaceTests.cs
+++ b/PitmastersGrill.Tests/Services/BoardPopulationSurfaceTests.cs
@@ -1,0 +1,120 @@
+using PitmastersGrill.Diagnostics;
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.Serialization;
+using System.Windows.Threading;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class BoardPopulationSurfaceTests
+    {
+        [Fact]
+        public void FinalizeBoardPopulationPass_WhenRetryableRowsRemain_RequestsRetryAndUpdatesStatus()
+        {
+            using var diagnostics = new MainWindowDiagnostics(Dispatcher.CurrentDispatcher);
+            var surface = CreateSurface(diagnostics);
+            var rows = new List<PilotBoardRow>
+            {
+                new()
+                {
+                    CharacterName = "Retry Me",
+                    IdentityStage = EnrichmentStageState.Throttled,
+                    AffiliationStage = EnrichmentStageState.Success,
+                    StatsStage = EnrichmentStageState.Success
+                },
+                new()
+                {
+                    CharacterName = "Done",
+                    IdentityStage = EnrichmentStageState.Success,
+                    AffiliationStage = EnrichmentStageState.Success,
+                    StatsStage = EnrichmentStageState.Success
+                }
+            };
+            var scheduled = false;
+            string? statusText = null;
+            BoardPopulationStatusKind? statusKind = null;
+
+            surface.FinalizeBoardPopulationPass(
+                generation: 5,
+                currentGeneration: 5,
+                currentRows: rows,
+                maxBoardPopulationRetryAttempts: 5,
+                updateBoardPopulationStatus: (text, kind) =>
+                {
+                    statusText = text;
+                    statusKind = kind;
+                },
+                scheduleBoardPopulationRetry: () => scheduled = true);
+
+            Assert.True(scheduled);
+            Assert.Equal(BoardPopulationStatusKind.Warning, statusKind);
+            Assert.Contains("retryable", statusText, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ClearBoard_ClearsRowsAndInvokesCallbacks()
+        {
+            using var diagnostics = new MainWindowDiagnostics(Dispatcher.CurrentDispatcher);
+            var surface = CreateSurface(diagnostics);
+            var rows = new ObservableCollection<PilotBoardRow>
+            {
+                new() { CharacterName = "Aura" },
+                new() { CharacterName = "Chribba" }
+            };
+            var saveCalls = 0;
+            var retryCancelled = 0;
+            var resetCalls = 0;
+            var sortResetCalls = 0;
+            var unsubscribeCalls = 0;
+            var recountCalls = 0;
+            var closeCalls = 0;
+            var detailButtonUpdates = 0;
+            var refreshedCalls = 0;
+            var generationIncrements = 0;
+            string? statusText = null;
+
+            surface.ClearBoard(
+                "test clear",
+                rows,
+                () => saveCalls++,
+                () => retryCancelled++,
+                () => resetCalls++,
+                () => sortResetCalls++,
+                () => unsubscribeCalls++,
+                () => recountCalls++,
+                () => closeCalls++,
+                () => detailButtonUpdates++,
+                () => refreshedCalls++,
+                (text, _) => statusText = text,
+                () => generationIncrements++);
+
+            Assert.Empty(rows);
+            Assert.Equal(1, saveCalls);
+            Assert.Equal(1, retryCancelled);
+            Assert.Equal(1, resetCalls);
+            Assert.Equal(1, sortResetCalls);
+            Assert.Equal(1, unsubscribeCalls);
+            Assert.Equal(1, recountCalls);
+            Assert.Equal(1, closeCalls);
+            Assert.Equal(1, detailButtonUpdates);
+            Assert.Equal(1, refreshedCalls);
+            Assert.Equal(1, generationIncrements);
+            Assert.Equal("Board cleared", statusText);
+        }
+
+#pragma warning disable SYSLIB0050
+        private static BoardPopulationSurface CreateSurface(MainWindowDiagnostics diagnostics)
+        {
+            var retryPolicy = new BoardPopulationRetryPolicy();
+            var passController = new BoardPopulationPassController(retryPolicy);
+            var retryController = new BoardPopulationRetryController(retryPolicy, diagnostics, defaultBoardPopulationRetryDelaySeconds: 12);
+            var entryController = (BoardPopulationEntryController)FormatterServices.GetUninitializedObject(typeof(BoardPopulationEntryController));
+            return new BoardPopulationSurface(entryController, passController, retryController, diagnostics);
+        }
+#pragma warning restore SYSLIB0050
+    }
+}

--- a/PitmastersGrill.Tests/Services/BoardSortControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/BoardSortControllerTests.cs
@@ -1,0 +1,132 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Data;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class BoardSortControllerTests
+    {
+        [Fact]
+        public void ResetManualBoardSort_SetsCharacterColumnAscending()
+        {
+            RunOnStaThread(() =>
+            {
+                var controller = new BoardSortController();
+                var grid = new DataGrid();
+                var characterColumn = new DataGridTextColumn
+                {
+                    SortMemberPath = nameof(PilotBoardRow.CharacterName),
+                    Binding = new Binding(nameof(PilotBoardRow.CharacterName))
+                };
+                var killsColumn = new DataGridTextColumn
+                {
+                    SortMemberPath = nameof(PilotBoardRow.KillCount),
+                    Binding = new Binding(nameof(PilotBoardRow.KillCount))
+                };
+                grid.Columns.Add(characterColumn);
+                grid.Columns.Add(killsColumn);
+
+                controller.ResetManualBoardSort(grid, characterColumn);
+
+                Assert.Equal(ListSortDirection.Ascending, characterColumn.SortDirection);
+                Assert.Null(killsColumn.SortDirection);
+            });
+        }
+
+        [Fact]
+        public void TryHandleSorting_TogglesDirectionAndReordersRows()
+        {
+            RunOnStaThread(() =>
+            {
+                var controller = new BoardSortController();
+                var grid = new DataGrid();
+                var killsColumn = new DataGridTextColumn
+                {
+                    SortMemberPath = nameof(PilotBoardRow.KillCount),
+                    Binding = new Binding(nameof(PilotBoardRow.KillCount))
+                };
+                grid.Columns.Add(killsColumn);
+                var rows = new ObservableCollection<PilotBoardRow>
+                {
+                    new() { CharacterName = "Alpha", KillCount = 2 },
+                    new() { CharacterName = "Bravo", KillCount = 9 }
+                };
+                var firstHandled = controller.TryHandleSorting(
+                    grid,
+                    killsColumn,
+                    rows,
+                    rows[0],
+                    out var firstMember,
+                    out var firstDirection);
+
+                Assert.True(firstHandled);
+                Assert.Equal(nameof(PilotBoardRow.KillCount), firstMember);
+                Assert.Equal(ListSortDirection.Ascending, firstDirection);
+                Assert.Equal("Alpha", rows[0].CharacterName);
+
+                var secondHandled = controller.TryHandleSorting(
+                    grid,
+                    killsColumn,
+                    rows,
+                    rows[0],
+                    out var secondMember,
+                    out var secondDirection);
+
+                Assert.True(secondHandled);
+                Assert.Equal(nameof(PilotBoardRow.KillCount), secondMember);
+                Assert.Equal(ListSortDirection.Descending, secondDirection);
+                Assert.Equal("Bravo", rows[0].CharacterName);
+                Assert.Equal(ListSortDirection.Descending, killsColumn.SortDirection);
+            });
+        }
+
+        [Fact]
+        public void ApplyCurrentBoardOrdering_PrioritizesWatchedRows()
+        {
+            var controller = new BoardSortController();
+            var rows = new ObservableCollection<PilotBoardRow>
+            {
+                new() { CharacterName = "Alpha", IsWatched = false },
+                new() { CharacterName = "Bravo", IsWatched = true }
+            };
+
+            controller.ApplyCurrentBoardOrdering(rows, null, _ => { });
+
+            Assert.Equal("Bravo", rows[0].CharacterName);
+            Assert.Equal("Alpha", rows[1].CharacterName);
+        }
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? capturedException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+            {
+                ExceptionDispatchInfo.Capture(capturedException).Throw();
+            }
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/DiagnosticsActionControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/DiagnosticsActionControllerTests.cs
@@ -1,0 +1,67 @@
+using PitmastersGrill.Services;
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class DiagnosticsActionControllerTests
+    {
+        [Fact]
+        public void SetStatus_TrimsMessage()
+        {
+            RunOnStaThread(() =>
+            {
+                var statusText = new TextBlock();
+                var controller = new DiagnosticsActionController(new Window(), statusText, new BrowserLauncher());
+
+                controller.SetStatus("  Cache refreshed.  ");
+
+                Assert.Equal("Cache refreshed.", statusText.Text);
+            });
+        }
+
+        [Fact]
+        public void SetStatus_UsesDefaultMessageForBlankInput()
+        {
+            RunOnStaThread(() =>
+            {
+                var statusText = new TextBlock();
+                var controller = new DiagnosticsActionController(new Window(), statusText, new BrowserLauncher());
+
+                controller.SetStatus("   ");
+
+                Assert.Equal("Diagnostics ready.", statusText.Text);
+            });
+        }
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? capturedException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+            {
+                ExceptionDispatchInfo.Capture(capturedException).Throw();
+            }
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/IntelStatusDetailsPresenterTests.cs
+++ b/PitmastersGrill.Tests/Services/IntelStatusDetailsPresenterTests.cs
@@ -1,0 +1,230 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows.Controls;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class IntelStatusDetailsPresenterTests
+    {
+        [Fact]
+        public void Apply_UpdatesRepresentativeFieldsAndButtonState()
+        {
+            RunOnStaThread(() =>
+            {
+                var controls = CreateControls();
+                var presenter = CreatePresenter(controls);
+                var projection = IntelStatusDetailsProjection.Create(
+                    new IntelUpdateStatusSnapshot
+                    {
+                        LastSuccessfulUpdateAtUtc = "2026-05-08T12:34:56Z",
+                        TotalProgressPercent = 42,
+                        TotalProgressText = "Importing day 3 of 7",
+                        LiveFeed = new R2Z2LiveFeedSnapshot
+                        {
+                            Enabled = true,
+                            Status = "Running",
+                            RecentLiveImportsCount = 7
+                        },
+                        TodaysFreshness = new TodaysFreshnessSnapshot
+                        {
+                            Status = "Idle",
+                            VisiblePilotsTargeted = 12,
+                            DetailText = "Today's Freshness is idle."
+                        },
+                        HistoricalFreshness = new HistoricalFreshnessSnapshot
+                        {
+                            Status = "Running",
+                            Mode = "Recent"
+                        }
+                    },
+                    isShuttingDown: false);
+
+                presenter.Apply(projection);
+
+                Assert.Equal("Importing day 3 of 7", controls.IntelTotalProgressText.Text);
+                Assert.Equal(42, controls.IntelTotalProgressBar.Value);
+                Assert.Equal("Yes", controls.IntelLiveFeedEnabledText.Text);
+                Assert.Equal("7", controls.IntelLiveFeedRecentImportsText.Text);
+                Assert.Equal("12", controls.TodaysFreshnessVisiblePilotsText.Text);
+                Assert.False(controls.RunTodaysFreshnessButton.IsEnabled);
+                Assert.Equal("Historical Freshness Running...", controls.RunTodaysFreshnessButton.Content);
+                Assert.Equal("Running", controls.HistoricalFreshnessStatusText.Text);
+                Assert.Equal("Recent", controls.HistoricalFreshnessModeText.Text);
+            });
+        }
+
+        private static IntelStatusDetailsPresenter CreatePresenter(IntelStatusControls controls)
+        {
+            return new IntelStatusDetailsPresenter(
+                controls.IntelLastUpdatedText,
+                controls.IntelOldestKillmailDayText,
+                controls.IntelNewestKillmailDayText,
+                controls.IntelCurrentUpdateStatusText,
+                controls.IntelTotalProgressBar,
+                controls.IntelTotalProgressText,
+                controls.IntelCurrentDayProgressBar,
+                controls.IntelCurrentDayProgressText,
+                controls.IntelLiveFeedSourceText,
+                controls.IntelLiveFeedStatusText,
+                controls.IntelLiveFeedEnabledText,
+                controls.IntelLiveFeedRecentImportsText,
+                controls.IntelLiveFeedNextSequenceText,
+                controls.IntelLiveFeedLastProcessedSequenceText,
+                controls.IntelLiveFeedLastSuccessText,
+                controls.IntelLiveFeedLastCaughtUpText,
+                controls.IntelLiveFeedLastErrorText,
+                controls.TodaysFreshnessStatusText,
+                controls.TodaysFreshnessVisiblePilotsText,
+                controls.TodaysFreshnessEntitiesQueriedText,
+                controls.TodaysFreshnessResultsFoundText,
+                controls.TodaysFreshnessKnownSkippedText,
+                controls.TodaysFreshnessImportedText,
+                controls.TodaysFreshnessFailedText,
+                controls.TodaysFreshnessLastRunText,
+                controls.TodaysFreshnessDetailText,
+                controls.TodaysFreshnessLastErrorText,
+                controls.RunTodaysFreshnessButton,
+                controls.HistoricalFreshnessStatusText,
+                controls.HistoricalFreshnessModeText,
+                controls.HistoricalFreshnessVisiblePilotsText,
+                controls.HistoricalFreshnessCandidatesConsideredText,
+                controls.HistoricalFreshnessCandidatesSkippedCooldownText,
+                controls.HistoricalFreshnessPilotsCheckedText,
+                controls.HistoricalFreshnessDaysCheckedText,
+                controls.HistoricalFreshnessEntitiesQueriedText,
+                controls.HistoricalFreshnessResultsFoundText,
+                controls.HistoricalFreshnessKnownSkippedText,
+                controls.HistoricalFreshnessImportedText,
+                controls.HistoricalFreshnessFailedText,
+                controls.HistoricalFreshnessLastRunText,
+                controls.HistoricalFreshnessDetailText,
+                controls.HistoricalFreshnessLastErrorText,
+                controls.RunHistoricalFreshnessButton);
+        }
+
+        private static IntelStatusControls CreateControls()
+        {
+            return new IntelStatusControls(
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new ProgressBar(),
+                new TextBlock(),
+                new ProgressBar(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new Button(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new TextBlock(),
+                new Button());
+        }
+
+        private sealed record IntelStatusControls(
+            TextBlock IntelLastUpdatedText,
+            TextBlock IntelOldestKillmailDayText,
+            TextBlock IntelNewestKillmailDayText,
+            TextBlock IntelCurrentUpdateStatusText,
+            ProgressBar IntelTotalProgressBar,
+            TextBlock IntelTotalProgressText,
+            ProgressBar IntelCurrentDayProgressBar,
+            TextBlock IntelCurrentDayProgressText,
+            TextBlock IntelLiveFeedSourceText,
+            TextBlock IntelLiveFeedStatusText,
+            TextBlock IntelLiveFeedEnabledText,
+            TextBlock IntelLiveFeedRecentImportsText,
+            TextBlock IntelLiveFeedNextSequenceText,
+            TextBlock IntelLiveFeedLastProcessedSequenceText,
+            TextBlock IntelLiveFeedLastSuccessText,
+            TextBlock IntelLiveFeedLastCaughtUpText,
+            TextBlock IntelLiveFeedLastErrorText,
+            TextBlock TodaysFreshnessStatusText,
+            TextBlock TodaysFreshnessVisiblePilotsText,
+            TextBlock TodaysFreshnessEntitiesQueriedText,
+            TextBlock TodaysFreshnessResultsFoundText,
+            TextBlock TodaysFreshnessKnownSkippedText,
+            TextBlock TodaysFreshnessImportedText,
+            TextBlock TodaysFreshnessFailedText,
+            TextBlock TodaysFreshnessLastRunText,
+            TextBlock TodaysFreshnessDetailText,
+            TextBlock TodaysFreshnessLastErrorText,
+            Button RunTodaysFreshnessButton,
+            TextBlock HistoricalFreshnessStatusText,
+            TextBlock HistoricalFreshnessModeText,
+            TextBlock HistoricalFreshnessVisiblePilotsText,
+            TextBlock HistoricalFreshnessCandidatesConsideredText,
+            TextBlock HistoricalFreshnessCandidatesSkippedCooldownText,
+            TextBlock HistoricalFreshnessPilotsCheckedText,
+            TextBlock HistoricalFreshnessDaysCheckedText,
+            TextBlock HistoricalFreshnessEntitiesQueriedText,
+            TextBlock HistoricalFreshnessResultsFoundText,
+            TextBlock HistoricalFreshnessKnownSkippedText,
+            TextBlock HistoricalFreshnessImportedText,
+            TextBlock HistoricalFreshnessFailedText,
+            TextBlock HistoricalFreshnessLastRunText,
+            TextBlock HistoricalFreshnessDetailText,
+            TextBlock HistoricalFreshnessLastErrorText,
+            Button RunHistoricalFreshnessButton);
+
+        private static void RunOnStaThread(Action action)
+        {
+            Exception? capturedException = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+            {
+                ExceptionDispatchInfo.Capture(capturedException).Throw();
+            }
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/MainWindowNativeInputControllerTests.cs
+++ b/PitmastersGrill.Tests/Services/MainWindowNativeInputControllerTests.cs
@@ -1,0 +1,76 @@
+using PitmastersGrill.Services;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class MainWindowNativeInputControllerTests
+    {
+        [Fact]
+        public void Attach_RegistersExpectedHotkeys_AndLogsFailures()
+        {
+            var controller = new MainWindowNativeInputController();
+            var registered = new List<int>();
+            var infoLogs = new List<string>();
+            var warnLogs = new List<string>();
+
+            controller.Attach(
+                new IntPtr(42),
+                _ => true,
+                (_, id, _, _) =>
+                {
+                    registered.Add(id);
+                    return id != 12;
+                },
+                modControl: 2,
+                globalResetWindowHotKeyId: 11,
+                globalClearBoardHotKeyId: 12,
+                globalToggleBoardModeHotKeyId: 13,
+                infoLogs.Add,
+                warnLogs.Add,
+                () => 99);
+
+            Assert.Equal(new[] { 12, 13, 11 }, registered);
+            Assert.Contains(infoLogs, message => message.Contains("Global Insert board-mode hotkey registered.", StringComparison.Ordinal));
+            Assert.Contains(infoLogs, message => message.Contains("Global Ctrl+Home reset-window hotkey registered.", StringComparison.Ordinal));
+            Assert.Contains(warnLogs, message => message.Contains("Global Delete clear-board hotkey registration failed. error=99", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void Detach_UnregistersOnlyRegisteredHotkeys()
+        {
+            var controller = new MainWindowNativeInputController();
+            var unregistered = new List<int>();
+
+            controller.Attach(
+                new IntPtr(42),
+                _ => true,
+                (_, _, _, _) => true,
+                modControl: 2,
+                globalResetWindowHotKeyId: 11,
+                globalClearBoardHotKeyId: 12,
+                globalToggleBoardModeHotKeyId: 13,
+                _ => { },
+                _ => { },
+                () => 0);
+
+            controller.Detach(
+                new IntPtr(42),
+                _ => true,
+                (_, id) =>
+                {
+                    unregistered.Add(id);
+                    return true;
+                },
+                globalResetWindowHotKeyId: 11,
+                globalClearBoardHotKeyId: 12,
+                globalToggleBoardModeHotKeyId: 13,
+                _ => { },
+                _ => { },
+                () => 0);
+
+            Assert.Equal(new[] { 12, 13, 11 }, unregistered);
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Services/WindowLayoutSurfaceTests.cs
+++ b/PitmastersGrill.Tests/Services/WindowLayoutSurfaceTests.cs
@@ -1,0 +1,94 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Services;
+using System.Collections.Generic;
+using System.Windows;
+using Xunit;
+
+namespace PitmastersGrill.Tests.Services
+{
+    public sealed class WindowLayoutSurfaceTests
+    {
+        private const double MinWidth = 200;
+        private const double MinHeight = 120;
+        private const double MinimumSavedWindowWidth = 420;
+        private const double MinimumSavedWindowHeight = 300;
+        private const double MinimumVisibleWindowEdge = 80;
+        private const double DefaultWindowWidth = 760;
+        private const double DefaultWindowHeight = 571;
+
+        [Fact]
+        public void RestoreFromSettings_AppliesBoundsAndTracksState()
+        {
+            var settings = new AppSettings
+            {
+                SavedNormalWindowLeft = 100,
+                SavedNormalWindowTop = 120,
+                SavedNormalWindowWidth = 800,
+                SavedNormalWindowHeight = 600,
+                SavedNormalWindowIsMaximized = true
+            };
+            var surface = new WindowLayoutSurface(
+                new WindowLayoutController(),
+                _ => { },
+                () => new List<Rect> { new(0, 0, 1920, 1080) });
+            var appliedBounds = Rect.Empty;
+            var appliedStates = new List<WindowState>();
+
+            surface.RestoreFromSettings(
+                settings,
+                WindowLayoutMode.Normal,
+                MinWidth,
+                MinHeight,
+                MinimumSavedWindowWidth,
+                MinimumSavedWindowHeight,
+                MinimumVisibleWindowEdge,
+                DefaultWindowWidth,
+                DefaultWindowHeight,
+                bounds => appliedBounds = bounds,
+                appliedStates.Add,
+                _ => { });
+
+            Assert.Equal(new Rect(100, 120, 800, 600), appliedBounds);
+            Assert.Equal(WindowState.Maximized, surface.LastNonMinimizedWindowState);
+            Assert.Equal(new Rect(100, 120, 800, 600), surface.LastKnownNormalBounds);
+            Assert.False(surface.IsRestoringWindowLayout);
+            Assert.Equal(new[] { WindowState.Normal, WindowState.Maximized }, appliedStates);
+        }
+
+        [Fact]
+        public void SaveToSettings_PersistsSnapshotUsingTrackedBounds()
+        {
+            var settings = new AppSettings();
+            var saveCount = 0;
+            var surface = new WindowLayoutSurface(
+                new WindowLayoutController(),
+                _ => saveCount++,
+                () => new List<Rect> { new(0, 0, 1920, 1080) });
+
+            surface.HandleWindowStateChanged(
+                WindowState.Normal,
+                Rect.Empty,
+                new Rect(40, 60, 900, 700));
+
+            surface.SaveToSettings(
+                settings,
+                "test save",
+                WindowLayoutMode.Board,
+                WindowState.Normal,
+                Rect.Empty,
+                new Rect(40, 60, 900, 700),
+                MinWidth,
+                MinHeight,
+                MinimumSavedWindowWidth,
+                MinimumSavedWindowHeight,
+                MinimumVisibleWindowEdge,
+                _ => { },
+                _ => { });
+
+            Assert.Equal(1, saveCount);
+            Assert.Equal(40, settings.SavedBoardWindowLeft);
+            Assert.Equal(700, settings.SavedBoardWindowHeight);
+            Assert.False(settings.SavedBoardWindowIsMaximized);
+        }
+    }
+}

--- a/PitmastersGrill.Tests/Ui/MainWindowSessionHotkeyTests.cs
+++ b/PitmastersGrill.Tests/Ui/MainWindowSessionHotkeyTests.cs
@@ -24,8 +24,10 @@ namespace PitmastersGrill.Tests.Ui
         {
             var code = ReadMainWindowCode();
             var coordinatorCode = ReadRepoFile("PitmastersGrill", "Services", "EveSessionContextCoordinator.cs");
+            var surfaceCode = ReadRepoFile("PitmastersGrill", "Services", "EveSessionContextSurface.cs");
 
-            Assert.Contains("_eveSessionContextCoordinator.CreatePendingContext()", code);
+            Assert.Contains("_eveSessionContextSurface.ApplyPendingContext()", code);
+            Assert.Contains("CreatePendingContext()", surfaceCode);
             Assert.Contains("Waiting for local session evidence", coordinatorCode);
             Assert.Contains("Soft local read pending", coordinatorCode);
         }

--- a/PitmastersGrill.Tests/Ui/MainWindowSessionHotkeyTests.cs
+++ b/PitmastersGrill.Tests/Ui/MainWindowSessionHotkeyTests.cs
@@ -10,13 +10,14 @@ namespace PitmastersGrill.Tests.Ui
         public void MainWindowCode_RegistersGlobalDeleteAndInsertHotkeys()
         {
             var code = ReadMainWindowCode();
+            var nativeInputControllerCode = ReadRepoFile("PitmastersGrill", "Services", "MainWindowNativeInputController.cs");
 
             Assert.Contains("GlobalClearBoardHotKeyId", code);
             Assert.Contains("GlobalToggleBoardModeHotKeyId", code);
-            Assert.Contains("Key.Delete", code);
-            Assert.Contains("Key.Insert", code);
-            Assert.Contains("TryRegisterGlobalBoardActionHotKeys", code);
-            Assert.Contains("TryUnregisterGlobalBoardActionHotKeys", code);
+            Assert.Contains("_mainWindowNativeInputController.Attach", code);
+            Assert.Contains("_mainWindowNativeInputController.Detach", code);
+            Assert.Contains("Key.Delete", nativeInputControllerCode);
+            Assert.Contains("Key.Insert", nativeInputControllerCode);
         }
 
         [Fact]

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -71,11 +71,14 @@ namespace PitmastersGrill
         private readonly MainWindowShellModeCoordinator _mainWindowShellModeCoordinator;
         private readonly MainWindowInteropController _mainWindowInteropController;
         private readonly WindowLayoutController _windowLayoutController;
+        private readonly WindowLayoutSurface _windowLayoutSurface;
+        private readonly MainWindowNativeInputController _mainWindowNativeInputController;
         private readonly BoardPopulationStatusController _boardPopulationStatusController;
         private readonly BoardPopulationRowProcessor _boardPopulationRowProcessor;
         private readonly BoardPopulationPassController _boardPopulationPassController;
         private readonly BoardPopulationRetryController _boardPopulationRetryController;
         private readonly BoardPopulationEntryController _boardPopulationEntryController;
+        private readonly BoardPopulationSurface _boardPopulationSurface;
         private readonly NotesRepository _notesRepository;
         private readonly WatchedPilotRepository _watchedPilotRepository;
         private readonly ZkillUrlBuilder _zkillUrlBuilder;
@@ -105,19 +108,14 @@ namespace PitmastersGrill
         private readonly ObservableCollection<AnalysisAffiliationListItem> _analysisCorpItems = new();
         private readonly CacheMaintenanceService _cacheMaintenanceService = new();
         private readonly KillmailDerivedIntelRebuildService _killmailDerivedIntelRebuildService = new();
-        private bool _isApplyingSettings; private bool _isRestoringWindowLayout;
+        private bool _isApplyingSettings;
         private bool _isShuttingDown;
         private bool _compactDragPending;
         private Point _compactDragStartPoint;
         private DateTime _lastEscapeTapUtc = DateTime.MinValue;
         private int _escapeTapCount;
         private int _processingGeneration;
-        private WindowState _lastNonMinimizedWindowState = WindowState.Normal;
-        private Rect _lastKnownNormalBounds = Rect.Empty;
         private bool? _lastAppliedCompactMode;
-        private bool _globalResetWindowHotKeyRegistered;
-        private bool _globalClearBoardHotKeyRegistered;
-        private bool _globalToggleBoardModeHotKeyRegistered;
         private bool _isMainWindowInitialized;
         public MainWindow(BackgroundIntelUpdateService backgroundIntelUpdateService)
         {
@@ -147,6 +145,7 @@ namespace PitmastersGrill
             _mainWindowShellModeCoordinator = new MainWindowShellModeCoordinator();
             _mainWindowInteropController = new MainWindowInteropController();
             _windowLayoutController = new WindowLayoutController();
+            _mainWindowNativeInputController = new MainWindowNativeInputController();
             _boardPopulationStatusController = new BoardPopulationStatusController();
             _pilotDetailActionsPresenter = new PilotDetailActionsPresenter();
 
@@ -184,6 +183,10 @@ namespace PitmastersGrill
             };
             _boardModeHintTimer.Tick += BoardModeHintTimer_Tick;
             _boardPopulationTimingMarkerTracker = new BoardPopulationTimingMarkerTracker();
+            _windowLayoutSurface = new WindowLayoutSurface(
+                _windowLayoutController,
+                settings => _mainWindowAppearanceController.SaveSettings(settings),
+                GetMonitorWorkAreasDip);
 
             AppLogger.UiInfo("MainWindow InitializeComponent complete.");
 
@@ -203,6 +206,11 @@ namespace PitmastersGrill
             _boardPopulationPassController = composed.BoardPopulationPassController;
             _boardPopulationRetryController = composed.BoardPopulationRetryController;
             _boardPopulationEntryController = composed.BoardPopulationEntryController;
+            _boardPopulationSurface = new BoardPopulationSurface(
+                _boardPopulationEntryController,
+                _boardPopulationPassController,
+                _boardPopulationRetryController,
+                _diagnostics);
             _ignoreAllianceCoordinator = composed.IgnoreAllianceCoordinator;
             _ignoreAllianceBoardController = composed.IgnoreAllianceBoardController;
             _zkillUrlBuilder = composed.ZkillUrlBuilder;
@@ -412,15 +420,22 @@ namespace PitmastersGrill
             base.OnSourceInitialized(e);
 
             var hwnd = new WindowInteropHelper(this).Handle;
-            AddClipboardFormatListener(hwnd);
-
             var source = HwndSource.FromHwnd(hwnd);
             source?.AddHook(WndProc);
 
             _mainWindowAppearanceController.ApplyTitleBarTheme(this, _appSettings.DarkModeEnabled);
             RestoreWindowLayoutFromSettings();
-            TryRegisterGlobalResetWindowHotKey(hwnd);
-            TryRegisterGlobalBoardActionHotKeys(hwnd);
+            _mainWindowNativeInputController.Attach(
+                hwnd,
+                AddClipboardFormatListener,
+                RegisterHotKey,
+                ModControl,
+                GlobalResetWindowHotKeyId,
+                GlobalClearBoardHotKeyId,
+                GlobalToggleBoardModeHotKeyId,
+                AppLogger.UiInfo,
+                AppLogger.UiWarn,
+                Marshal.GetLastWin32Error);
             UpdateWindowStateUi();
             _eveSessionContextSurface.TriggerRefresh("startup", force: false);
 
@@ -477,9 +492,16 @@ namespace PitmastersGrill
             _diagnostics.Dispose();
 
             var hwnd = new WindowInteropHelper(this).Handle;
-            TryUnregisterGlobalBoardActionHotKeys(hwnd);
-            TryUnregisterGlobalResetWindowHotKey(hwnd);
-            RemoveClipboardFormatListener(hwnd);
+            _mainWindowNativeInputController.Detach(
+                hwnd,
+                RemoveClipboardFormatListener,
+                UnregisterHotKey,
+                GlobalResetWindowHotKeyId,
+                GlobalClearBoardHotKeyId,
+                GlobalToggleBoardModeHotKeyId,
+                AppLogger.UiInfo,
+                AppLogger.UiWarn,
+                Marshal.GetLastWin32Error);
 
             AppLogger.UiInfo("MainWindow closed. Clipboard listener removed, retry state cancelled, and background work stop requested.");
 
@@ -512,7 +534,7 @@ namespace PitmastersGrill
                 CompactModeToggleButton.IsChecked == true,
                 _lastAppliedCompactMode,
                 _isApplyingSettings,
-                _isRestoringWindowLayout,
+                _windowLayoutSurface.IsRestoringWindowLayout,
                 _appSettings.CompactModeEnabled,
                 MainTabControl.SelectedIndex);
 
@@ -715,20 +737,11 @@ namespace PitmastersGrill
             MaximizeRestoreWindowButton.ToolTip = buttonState.ToolTip;
         }
 
-        private void TrackCurrentNormalWindowBounds(string reason)
+        private void TrackCurrentNormalWindowBounds()
         {
-            if (WindowState != WindowState.Normal)
-            {
-                return;
-            }
-
-            var currentBounds = new Rect(Left, Top, Width, Height);
-            if (!_windowLayoutController.IsUsableWindowBounds(currentBounds))
-            {
-                return;
-            }
-
-            _lastKnownNormalBounds = currentBounds;
+            _windowLayoutSurface.TrackCurrentNormalWindowBounds(
+                WindowState,
+                new Rect(Left, Top, Width, Height));
         }
 
         private void RequestApplicationShutdown(string reason)
@@ -825,31 +838,21 @@ namespace PitmastersGrill
 
         private void Window_StateChanged(object? sender, EventArgs e)
         {
-            if (WindowState != WindowState.Minimized)
-            {
-                _lastNonMinimizedWindowState = WindowState;
-            }
-
-            if (WindowState == WindowState.Maximized && _windowLayoutController.IsUsableWindowBounds(RestoreBounds))
-            {
-                _lastKnownNormalBounds = RestoreBounds;
-            }
-            else if (WindowState == WindowState.Normal)
-            {
-                TrackCurrentNormalWindowBounds("StateChanged");
-            }
-
+            _windowLayoutSurface.HandleWindowStateChanged(
+                WindowState,
+                RestoreBounds,
+                new Rect(Left, Top, Width, Height));
             UpdateWindowStateUi();
         }
 
         private void Window_LocationChanged(object sender, EventArgs e)
         {
-            TrackCurrentNormalWindowBounds("LocationChanged");
+            TrackCurrentNormalWindowBounds();
         }
 
         private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            TrackCurrentNormalWindowBounds("SizeChanged");
+            TrackCurrentNormalWindowBounds();
             UpdateWindowMinimumSize();
         }
 
@@ -912,8 +915,7 @@ namespace PitmastersGrill
             Top = resetBounds.Top;
             Width = resetBounds.Width;
             Height = resetBounds.Height;
-            _lastKnownNormalBounds = resetBounds;
-            _lastNonMinimizedWindowState = WindowState.Normal;
+            _windowLayoutSurface.HandleWindowStateChanged(WindowState.Normal, Rect.Empty, resetBounds);
 
             SaveWindowLayoutToSettings(reason);
 
@@ -1344,123 +1346,11 @@ namespace PitmastersGrill
 
             return IntPtr.Zero;
         }
-
-        private void TryRegisterGlobalBoardActionHotKeys(IntPtr hwnd)
-        {
-            if (hwnd == IntPtr.Zero)
-            {
-                return;
-            }
-
-            _globalClearBoardHotKeyRegistered = RegisterHotKey(
-                hwnd,
-                GlobalClearBoardHotKeyId,
-                0,
-                (uint)KeyInterop.VirtualKeyFromKey(Key.Delete));
-
-            if (_globalClearBoardHotKeyRegistered)
-            {
-                AppLogger.UiInfo("Global Delete clear-board hotkey registered.");
-            }
-            else
-            {
-                AppLogger.UiWarn($"Global Delete clear-board hotkey registration failed. error={Marshal.GetLastWin32Error()}");
-            }
-
-            _globalToggleBoardModeHotKeyRegistered = RegisterHotKey(
-                hwnd,
-                GlobalToggleBoardModeHotKeyId,
-                0,
-                (uint)KeyInterop.VirtualKeyFromKey(Key.Insert));
-
-            if (_globalToggleBoardModeHotKeyRegistered)
-            {
-                AppLogger.UiInfo("Global Insert board-mode hotkey registered.");
-            }
-            else
-            {
-                AppLogger.UiWarn($"Global Insert board-mode hotkey registration failed. error={Marshal.GetLastWin32Error()}");
-            }
-        }
-
-        private void TryRegisterGlobalResetWindowHotKey(IntPtr hwnd)
-        {
-            if (hwnd == IntPtr.Zero)
-            {
-                return;
-            }
-
-            _globalResetWindowHotKeyRegistered = RegisterHotKey(
-                hwnd,
-                GlobalResetWindowHotKeyId,
-                ModControl,
-                (uint)KeyInterop.VirtualKeyFromKey(Key.Home));
-
-            if (_globalResetWindowHotKeyRegistered)
-            {
-                AppLogger.UiInfo("Global Ctrl+Home reset-window hotkey registered.");
-                return;
-            }
-
-            AppLogger.UiWarn($"Global Ctrl+Home hotkey registration failed. win32Error={Marshal.GetLastWin32Error()}");
-        }
-
-        private void TryUnregisterGlobalBoardActionHotKeys(IntPtr hwnd)
-        {
-            if (hwnd == IntPtr.Zero)
-            {
-                return;
-            }
-
-            if (_globalClearBoardHotKeyRegistered)
-            {
-                if (UnregisterHotKey(hwnd, GlobalClearBoardHotKeyId))
-                {
-                    AppLogger.UiInfo("Global Delete clear-board hotkey unregistered.");
-                }
-                else
-                {
-                    AppLogger.UiWarn($"Global Delete clear-board hotkey unregister failed. error={Marshal.GetLastWin32Error()}");
-                }
-
-                _globalClearBoardHotKeyRegistered = false;
-            }
-
-            if (_globalToggleBoardModeHotKeyRegistered)
-            {
-                if (UnregisterHotKey(hwnd, GlobalToggleBoardModeHotKeyId))
-                {
-                    AppLogger.UiInfo("Global Insert board-mode hotkey unregistered.");
-                }
-                else
-                {
-                    AppLogger.UiWarn($"Global Insert board-mode hotkey unregister failed. error={Marshal.GetLastWin32Error()}");
-                }
-
-                _globalToggleBoardModeHotKeyRegistered = false;
-            }
-        }
-
-        private void TryUnregisterGlobalResetWindowHotKey(IntPtr hwnd)
-        {
-            if (!_globalResetWindowHotKeyRegistered || hwnd == IntPtr.Zero)
-            {
-                return;
-            }
-
-            if (!UnregisterHotKey(hwnd, GlobalResetWindowHotKeyId))
-            {
-                AppLogger.UiWarn($"Global Ctrl+Home hotkey unregistration failed. win32Error={Marshal.GetLastWin32Error()}");
-            }
-
-            _globalResetWindowHotKeyRegistered = false;
-        }
-
         private void ScheduleClipboardProcessing()
         {
-            _clipboardDebounceTimer.Stop();
-            _clipboardDebounceTimer.Start();
-            _diagnostics.ClipboardChangeDebounced(ClipboardDebounceMilliseconds);
+            _boardPopulationSurface.ScheduleClipboardProcessing(
+                _clipboardDebounceTimer,
+                ClipboardDebounceMilliseconds);
         }
 
         private void ClipboardDebounceTimer_Tick(object? sender, EventArgs e)
@@ -1472,7 +1362,7 @@ namespace PitmastersGrill
 
         private Task ProcessClipboardIfValidAsync()
         {
-            return _boardPopulationEntryController.ProcessClipboardIfValidAsync(
+            return _boardPopulationSurface.ProcessClipboardIfValidAsync(
                 clipboardContainsText: () => Clipboard.ContainsText(),
                 clipboardGetText: () => Clipboard.GetText(),
                 setBoardButtonsEnabled: enabled =>
@@ -1489,13 +1379,10 @@ namespace PitmastersGrill
 
         private Task ProcessNamesAsync(List<string> characterNames, bool isRetryPass)
         {
-            _eveSessionContextSurface.TriggerRefresh(
-                isRetryPass ? "board retry pass" : "accepted local clipboard",
-                force: !isRetryPass);
-
-            return _boardPopulationEntryController.ProcessNamesAsync(
+            return _boardPopulationSurface.ProcessNamesAsync(
                 characterNames,
                 isRetryPass,
+                (reason, force) => _eveSessionContextSurface.TriggerRefresh(reason, force),
                 SaveCurrentNotesAndTags,
                 BuildInitialBoard,
                 beginProcessingGeneration: () => ++_processingGeneration,
@@ -1517,63 +1404,18 @@ namespace PitmastersGrill
 
         private void FinalizeBoardPopulationPass(int generation)
         {
-            if (generation != _processingGeneration)
-            {
-                _diagnostics.FinalizeSkipped(generation, _processingGeneration);
-                return;
-            }
-
-            var decision = _boardPopulationPassController.BuildFinalizeDecision(
-                _currentRows,
-                _boardPopulationRetryController.RetryAttempt,
-                MaxBoardPopulationRetryAttempts);
-
-            if (decision.IsComplete)
-            {
-                _boardPopulationRetryController.MarkComplete();
-
-                _diagnostics.BoardProcessFinalizedComplete(
-                    generation,
-                    decision.CompleteCount,
-                    decision.PartialCount,
-                    decision.RetryableCount);
-
-                UpdateBoardPopulationStatus(decision.StatusText, decision.StatusKind);
-                return;
-            }
-
-            _boardPopulationRetryController.MarkIncomplete();
-            _boardPopulationEntryController.InvalidateLastProcessedClipboard();
-
-            if (decision.RetryLimitReached)
-            {
-                _diagnostics.BoardProcessRetryLimitReached(
-                    generation,
-                    decision.RetryableCount,
-                    decision.PartialCount,
-                    _boardPopulationRetryController.RetryAttempt);
-
-                UpdateBoardPopulationStatus(decision.StatusText, decision.StatusKind);
-                return;
-            }
-
-            _diagnostics.BoardProcessRequiresRetry(
+            _boardPopulationSurface.FinalizeBoardPopulationPass(
                 generation,
-                decision.RetryableCount,
-                decision.PartialCount,
-                _boardPopulationRetryController.RetryAttempt);
-
-            UpdateBoardPopulationStatus(decision.StatusText, decision.StatusKind);
-
-            if (decision.ShouldScheduleRetry)
-            {
-                ScheduleBoardPopulationRetry();
-            }
+                _processingGeneration,
+                _currentRows,
+                MaxBoardPopulationRetryAttempts,
+                UpdateBoardPopulationStatus,
+                ScheduleBoardPopulationRetry);
         }
 
         private void ScheduleBoardPopulationRetry()
         {
-            _boardPopulationRetryController.ScheduleRetry(
+            _boardPopulationSurface.ScheduleBoardPopulationRetry(
                 _currentRows,
                 Dispatcher,
                 UpdateBoardPopulationStatus,
@@ -1582,7 +1424,7 @@ namespace PitmastersGrill
 
         private Task ProcessRetryPassAsync()
         {
-            return _boardPopulationRetryController.ProcessRetryPassAsync(
+            return _boardPopulationSurface.ProcessRetryPassAsync(
                 _currentRows,
                 () => _backgroundIntelUpdateService.BeginForegroundPriority(),
                 (rows, generation) => ProcessRowBatchAsync(rows.ToList(), generation),
@@ -1593,7 +1435,7 @@ namespace PitmastersGrill
 
         private void CancelBoardPopulationRetry()
         {
-            _boardPopulationRetryController.CancelRetry();
+            _boardPopulationSurface.CancelBoardPopulationRetry();
         }
 
         private void ResetBoardPopulationTracking(bool preserveLastProcessedClipboardText = false)
@@ -1604,8 +1446,7 @@ namespace PitmastersGrill
 
         private void ResetEntryAndRetryTracking(bool preserveLastProcessedClipboardText = false)
         {
-            _boardPopulationEntryController.ResetTracking(preserveLastProcessedClipboardText);
-            _boardPopulationRetryController.ResetTracking();
+            _boardPopulationSurface.ResetBoardPopulationTracking(preserveLastProcessedClipboardText);
         }
 
         private void UpdateBoardPopulationStatus(string statusText, BoardPopulationStatusKind kind)
@@ -2105,28 +1946,21 @@ namespace PitmastersGrill
 
         private void ClearBoard(string reason)
         {
-            var clearedRowCount = _currentRows.Count;
-
-            _diagnostics.ClearBoardStart(clearedRowCount);
-
-            SaveCurrentNotesAndTags();
-            CancelBoardPopulationRetry();
-            _processingGeneration++;
-            ResetEntryAndRetryTracking();
-            ResetManualBoardSort();
-            UnsubscribeFromAllBoardRows();
-
             PilotBoard.SelectedItem = null;
-            _currentRows.Clear();
-            RecomputeCorpAllianceCounts();
-            CloseActiveDetailWindow();
-            UpdateOpenDetailsButtonState();
-
-            UpdateLastRefreshed();
-            UpdateBoardPopulationStatus("Board cleared", BoardPopulationStatusKind.Neutral);
-
-            AppLogger.UiInfo($"Board cleared. reason='{reason}' removedRows={clearedRowCount}");
-            _diagnostics.ClearBoardComplete();
+            _boardPopulationSurface.ClearBoard(
+                reason,
+                _currentRows,
+                SaveCurrentNotesAndTags,
+                CancelBoardPopulationRetry,
+                () => ResetEntryAndRetryTracking(),
+                ResetManualBoardSort,
+                UnsubscribeFromAllBoardRows,
+                RecomputeCorpAllianceCounts,
+                CloseActiveDetailWindow,
+                UpdateOpenDetailsButtonState,
+                UpdateLastRefreshed,
+                UpdateBoardPopulationStatus,
+                () => _processingGeneration++);
         }
 
         private void OpenZkillButton_Click(object sender, RoutedEventArgs e)
@@ -2755,16 +2589,57 @@ namespace PitmastersGrill
             }
         }
 
-        private WindowLayoutMode GetCurrentWindowLayoutMode() { return CompactModeToggleButton?.IsChecked == true ? WindowLayoutMode.Board : WindowLayoutMode.Normal; }
-        private void RestoreWindowLayoutFromSettings() { RestoreWindowLayoutFromSettings(GetCurrentWindowLayoutMode()); }
-        private void RestoreWindowLayoutFromSettings(WindowLayoutMode mode) { var workAreas = GetMonitorWorkAreasDip(); var virtualDesktopSummary = _windowLayoutController.BuildVirtualDesktopSummary(workAreas); var restoreResult = _windowLayoutController.BuildRestoreResult(_appSettings, mode, MinWidth, MinHeight, MinimumSavedWindowWidth, MinimumSavedWindowHeight, MinimumVisibleWindowEdge, DefaultWindowWidth, DefaultWindowHeight, workAreas); AppLogger.UiInfo($"Window layout restore decision={restoreResult.RestoreDecision} mode={mode} savedBounds={_windowLayoutController.DescribeRect(restoreResult.SavedBounds)} fallbackReason='{restoreResult.RestoreReason}' wasMaximized={restoreResult.ShouldRestoreMaximized} virtualWorkAreas={virtualDesktopSummary}"); _isRestoringWindowLayout = true; try { WindowState = WindowState.Normal; Left = restoreResult.TargetBounds.Left; Top = restoreResult.TargetBounds.Top; Width = restoreResult.TargetBounds.Width; Height = restoreResult.TargetBounds.Height; _lastKnownNormalBounds = restoreResult.TargetBounds; if (restoreResult.ShouldRestoreMaximized) { WindowState = WindowState.Maximized; } _lastNonMinimizedWindowState = restoreResult.LastNonMinimizedWindowState; } finally { _isRestoringWindowLayout = false; } AppLogger.UiInfo($"Window layout restore applied mode={mode} finalBounds={_windowLayoutController.DescribeRect(restoreResult.TargetBounds)} finalWindowState={WindowState}"); }
-        private void SaveWindowLayoutToSettings(string reason) { SaveWindowLayoutToSettings(reason, GetCurrentWindowLayoutMode()); }
-        private void SaveWindowLayoutToSettings(string reason, WindowLayoutMode mode) { var effectiveState = WindowState == WindowState.Minimized ? _lastNonMinimizedWindowState : WindowState; if (effectiveState == WindowState.Maximized && _windowLayoutController.IsUsableWindowBounds(RestoreBounds)) { _lastKnownNormalBounds = RestoreBounds; } else if (WindowState == WindowState.Normal) { TrackCurrentNormalWindowBounds("Save"); } var bounds = _windowLayoutController.IsUsableWindowBounds(_lastKnownNormalBounds) ? _lastKnownNormalBounds : effectiveState == WindowState.Maximized ? RestoreBounds : new Rect(Left, Top, Width, Height); var workAreas = GetMonitorWorkAreasDip(); if (!_windowLayoutController.TryBuildLayoutSnapshot(bounds, effectiveState, MinWidth, MinHeight, MinimumSavedWindowWidth, MinimumSavedWindowHeight, MinimumVisibleWindowEdge, workAreas, out var snapshot, out var failureReason)) { AppLogger.UiWarn($"Window layout save skipped.\nreason='{reason}' mode={mode} bounds={_windowLayoutController.DescribeRect(bounds)} failureReason='{failureReason}' virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}"); return; } _windowLayoutController.ApplySnapshot(_appSettings, snapshot, mode); _mainWindowAppearanceController.SaveSettings(_appSettings); AppLogger.UiInfo($"Window layout saved.\nreason='{reason}' mode={mode} bounds={_windowLayoutController.DescribeRect(bounds)} maximized={snapshot.IsMaximized} virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}"); }
-        private void ClearSavedWindowLayoutSettings() { _windowLayoutController.ClearAllSavedLayouts(_appSettings); _mainWindowAppearanceController.SaveSettings(_appSettings); }
+        private WindowLayoutMode GetCurrentWindowLayoutMode() => CompactModeToggleButton?.IsChecked == true ? WindowLayoutMode.Board : WindowLayoutMode.Normal;
+
+        private void RestoreWindowLayoutFromSettings() => RestoreWindowLayoutFromSettings(GetCurrentWindowLayoutMode());
+
+        private void RestoreWindowLayoutFromSettings(WindowLayoutMode mode)
+        {
+            _windowLayoutSurface.RestoreFromSettings(
+                _appSettings,
+                mode,
+                MinWidth,
+                MinHeight,
+                MinimumSavedWindowWidth,
+                MinimumSavedWindowHeight,
+                MinimumVisibleWindowEdge,
+                DefaultWindowWidth,
+                DefaultWindowHeight,
+                bounds =>
+                {
+                    Left = bounds.Left;
+                    Top = bounds.Top;
+                    Width = bounds.Width;
+                    Height = bounds.Height;
+                },
+                state => WindowState = state,
+                AppLogger.UiInfo);
+        }
+
+        private void SaveWindowLayoutToSettings(string reason) => SaveWindowLayoutToSettings(reason, GetCurrentWindowLayoutMode());
+
+        private void SaveWindowLayoutToSettings(string reason, WindowLayoutMode mode)
+        {
+            _windowLayoutSurface.SaveToSettings(
+                _appSettings,
+                reason,
+                mode,
+                WindowState,
+                RestoreBounds,
+                new Rect(Left, Top, Width, Height),
+                MinWidth,
+                MinHeight,
+                MinimumSavedWindowWidth,
+                MinimumSavedWindowHeight,
+                MinimumVisibleWindowEdge,
+                AppLogger.UiInfo,
+                AppLogger.UiWarn);
+        }
+
+        private void ClearSavedWindowLayoutSettings() => _windowLayoutSurface.ClearSavedLayouts(_appSettings);
         private Rect GetDefaultWindowBoundsForCurrentDisplay()
         {
-            return _windowLayoutController.GetDefaultWindowBounds(
-                GetMonitorWorkAreasDip(),
+            return _windowLayoutSurface.GetDefaultWindowBounds(
                 MinimumSavedWindowWidth,
                 MinimumSavedWindowHeight,
                 DefaultWindowWidth,

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace PitmastersGrill
         private readonly BoardColumnLayoutController _boardColumnLayoutController;
         private readonly BoardColumnSettingsController _boardColumnSettingsController;
         private readonly BoardColumnLayoutPersistenceController _boardColumnLayoutPersistenceController;
+        private readonly BoardSortController _boardSortController;
         private readonly SettingsTabController _settingsTabController;
         private readonly AnalysisTabController _analysisTabController;
         private readonly AnalysisTabPresenter _analysisTabPresenter = null!;
@@ -81,12 +82,11 @@ namespace PitmastersGrill
         private readonly BrowserLauncher _browserLauncher;
         private ManualUpdateCheckController? _manualUpdateCheckController;
         private readonly DiagnosticsSupportSurface _diagnosticsSupportSurface = null!;
-        private readonly EveSessionContextService _eveSessionContextService;
         private readonly MainWindowDiagnostics _diagnostics;
         private readonly IntelSupportSurface _intelSupportSurface = null!;
         private readonly PilotDetailActionsPresenter _pilotDetailActionsPresenter;
-        private readonly PilotDetailWindowPlacementController _pilotDetailWindowPlacementController;
-        private readonly PilotDetailWindowLifecycleController _pilotDetailWindowLifecycleController;
+        private readonly PilotDetailSurface _pilotDetailSurface = null!;
+        private readonly EveSessionContextSurface _eveSessionContextSurface = null!;
         private readonly BoardPopulationTimingMarkerTracker _boardPopulationTimingMarkerTracker;
         private readonly IgnoreAllianceCoordinator _ignoreAllianceCoordinator;
         private readonly IgnoreAllianceBoardController _ignoreAllianceBoardController;
@@ -105,7 +105,6 @@ namespace PitmastersGrill
         private readonly ObservableCollection<AnalysisAffiliationListItem> _analysisCorpItems = new();
         private readonly CacheMaintenanceService _cacheMaintenanceService = new();
         private readonly KillmailDerivedIntelRebuildService _killmailDerivedIntelRebuildService = new();
-        private PilotDetailWindow? _activePilotDetailWindow;
         private bool _isApplyingSettings; private bool _isRestoringWindowLayout;
         private bool _isShuttingDown;
         private bool _compactDragPending;
@@ -115,17 +114,11 @@ namespace PitmastersGrill
         private int _processingGeneration;
         private WindowState _lastNonMinimizedWindowState = WindowState.Normal;
         private Rect _lastKnownNormalBounds = Rect.Empty;
-        private string? _activeBoardSortMemberPath;
-        private ListSortDirection? _activeBoardSortDirection;
         private bool? _lastAppliedCompactMode;
         private bool _globalResetWindowHotKeyRegistered;
         private bool _globalClearBoardHotKeyRegistered;
         private bool _globalToggleBoardModeHotKeyRegistered;
         private bool _isMainWindowInitialized;
-        private EveSessionContext? _currentEveSessionContext;
-        private DateTime _lastSessionContextRefreshUtc = DateTime.MinValue;
-        private bool _isSessionContextRefreshInFlight;
-
         public MainWindow(BackgroundIntelUpdateService backgroundIntelUpdateService)
         {
             AppLogger.UiInfo("MainWindow constructor begin.");
@@ -137,6 +130,7 @@ namespace PitmastersGrill
             _eveSessionContextCoordinator = new EveSessionContextCoordinator();
             _boardDisplaySettingsController = new BoardDisplaySettingsController();
             _boardColumnLayoutController = new BoardColumnLayoutController();
+            _boardSortController = new BoardSortController();
             _boardColumnSettingsController = new BoardColumnSettingsController(
                 _boardColumnLayoutController,
                 settings => _mainWindowAppearanceController.SaveSettings(settings));
@@ -155,8 +149,6 @@ namespace PitmastersGrill
             _windowLayoutController = new WindowLayoutController();
             _boardPopulationStatusController = new BoardPopulationStatusController();
             _pilotDetailActionsPresenter = new PilotDetailActionsPresenter();
-            _pilotDetailWindowPlacementController = new PilotDetailWindowPlacementController();
-            _pilotDetailWindowLifecycleController = new PilotDetailWindowLifecycleController();
 
             _isApplyingSettings = true;
             AppLogger.UiInfo("MainWindow InitializeComponent begin.");
@@ -230,7 +222,7 @@ namespace PitmastersGrill
                 AnalysisHighlightsText,
                 _analysisAllianceItems,
                 _analysisCorpItems);
-            _eveSessionContextService = new EveSessionContextService();
+            var eveSessionContextService = new EveSessionContextService();
 
             _ignoreAllianceListView = IgnoreAllianceListViewControl;
             _ignoreAllianceListView.Initialize(_ignoreAllianceCoordinator);
@@ -301,6 +293,55 @@ namespace PitmastersGrill
                 RefreshCacheStatsUi,
                 RefreshConfirmedCynoModuleStateForCurrentRows,
                 (message, title, buttons, image) => MessageBox.Show(this, message, title, buttons, image));
+            _pilotDetailSurface = new PilotDetailSurface(
+                this,
+                DetailPane,
+                SelectedCharacterText,
+                FullCorpText,
+                FullAllianceText,
+                FreshnessText,
+                RecentPublicActivityText,
+                CynoSignalText,
+                CynoConfidenceBar,
+                CynoEvidenceText,
+                CynoLimitationsText,
+                ExplainabilityText,
+                NotesTagsBox,
+                KnownCynoOverrideCheckBox,
+                BaitOverrideCheckBox,
+                IgnoreAllianceButton,
+                WatchPilotDetailAction,
+                _detailPaneController,
+                new PilotDetailWindowLifecycleController(),
+                new PilotDetailWindowPlacementController(),
+                _pilotBoardRowDetailFormatter,
+                _pilotDetailActionsPresenter,
+                _watchedPilotRepository,
+                _notesRepository,
+                _settingsTabController,
+                () => _appSettings,
+                allianceId => _ignoreAllianceCoordinator.ContainsAllianceId(allianceId),
+                (selectedRow, currentRows) => _detailPaneController.GetSelectedOrDisplayedDetailRow(
+                    selectedRow,
+                    DetailPane.Visibility,
+                    SelectedCharacterText.Text,
+                    currentRows),
+                TryIgnoreForRow,
+                OpenZkillForRow,
+                ApplyCurrentBoardOrdering,
+                RefreshDetailWindowIfSelected,
+                DetailWindowGap);
+            _eveSessionContextSurface = new EveSessionContextSurface(
+                Dispatcher,
+                _eveSessionContextCoordinator,
+                eveSessionContextService.CaptureAsync,
+                () => _isShuttingDown,
+                _windowShutdownCts.Token,
+                AnalysisCurrentCharacterText,
+                AnalysisCurrentSystemText,
+                AnalysisEvidenceSourceText,
+                AnalysisObservedAtText,
+                AnalysisContextStatusText);
             _mainWindowAppearanceController.ApplyPanelModeShell(this, _appSettings, Resources);
             CompactModeToggleButton.IsChecked = _appSettings.CompactModeEnabled;
 
@@ -355,7 +396,7 @@ namespace PitmastersGrill
             UpdateBoardSummaryBanner();
             UpdateAnalysisTab();
             _intelSupportSurface.ApplySnapshot(_backgroundIntelUpdateService.GetSnapshot(), _isShuttingDown);
-            ApplyEveSessionContext(_eveSessionContextCoordinator.CreatePendingContext());
+            _eveSessionContextSurface.ApplyPendingContext();
             _isMainWindowInitialized = true;
 
             AppLogger.DatabaseInfo(
@@ -381,7 +422,7 @@ namespace PitmastersGrill
             TryRegisterGlobalResetWindowHotKey(hwnd);
             TryRegisterGlobalBoardActionHotKeys(hwnd);
             UpdateWindowStateUi();
-            TriggerSessionContextRefresh("startup", force: false);
+            _eveSessionContextSurface.TriggerRefresh("startup", force: false);
 
             AppLogger.UiInfo("MainWindow source initialized. Clipboard listener attached and title bar theme applied.");
         }
@@ -544,7 +585,7 @@ namespace PitmastersGrill
 
             if (MainTabControl.SelectedIndex == 0)
             {
-                TriggerSessionContextRefresh("analysis tab selection", force: IsSessionContextStale());
+                _eveSessionContextSurface.TriggerRefresh("analysis tab selection", force: _eveSessionContextSurface.IsStale(DateTime.UtcNow));
             }
             else if (MainTabControl.SelectedIndex == 1)
             {
@@ -821,7 +862,7 @@ namespace PitmastersGrill
                 Resources,
                 this,
                 ApplyBoardPopulationStatusVisual,
-                () => _activePilotDetailWindow?.ApplyThemeResources(Resources));
+                () => _pilotDetailSurface.ApplyThemeToActiveWindow(Resources));
         }
 
         private void AlwaysOnTopCheckBox_Changed(object sender, RoutedEventArgs e)
@@ -853,7 +894,7 @@ namespace PitmastersGrill
                 this,
                 WindowOpacityValueText,
                 Resources,
-                () => _activePilotDetailWindow?.ApplyThemeResources(Resources));
+                () => _pilotDetailSurface.ApplyThemeToActiveWindow(Resources));
         }
 
         private void ResetWindowLayoutButton_Click(object sender, RoutedEventArgs e)
@@ -940,7 +981,7 @@ namespace PitmastersGrill
                 Resources,
                 this,
                 ApplyBoardPopulationStatusVisual,
-                () => _activePilotDetailWindow?.ApplyThemeResources(Resources));
+                () => _pilotDetailSurface.ApplyThemeToActiveWindow(Resources));
         }
 
         private void ColorBlindModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -952,7 +993,7 @@ namespace PitmastersGrill
                 Resources,
                 this,
                 ApplyBoardPopulationStatusVisual,
-                () => _activePilotDetailWindow?.ApplyThemeResources(Resources),
+                () => _pilotDetailSurface.ApplyThemeToActiveWindow(Resources),
                 () => PilotBoard?.Items.Refresh());
         }
 
@@ -1448,7 +1489,7 @@ namespace PitmastersGrill
 
         private Task ProcessNamesAsync(List<string> characterNames, bool isRetryPass)
         {
-            TriggerSessionContextRefresh(
+            _eveSessionContextSurface.TriggerRefresh(
                 isRetryPass ? "board retry pass" : "accepted local clipboard",
                 force: !isRetryPass);
 
@@ -1747,12 +1788,7 @@ namespace PitmastersGrill
         {
             _pilotBoardRowDetailFormatter.UpdateConfirmedCynoModuleState(row);
             RecomputeCorpAllianceCounts();
-
-            if (_activePilotDetailWindow != null &&
-                _pilotDetailWindowLifecycleController.ShouldRefreshActiveWindow(row.CharacterName))
-            {
-                _activePilotDetailWindow.RefreshRow();
-            }
+            _pilotDetailSurface.RefreshActiveDetailWindowIfSelected(row);
         }
 
         private void RefreshConfirmedCynoModuleStateForCurrentRows()
@@ -1846,35 +1882,17 @@ namespace PitmastersGrill
 
         private void PilotBoard_Sorting(object sender, DataGridSortingEventArgs e)
         {
-            if (PilotBoard == null)
-            {
-                return;
-            }
-
             e.Handled = true;
-
-            var sortMemberPath = e.Column.SortMemberPath;
-            if (string.IsNullOrWhiteSpace(sortMemberPath))
+            if (_boardSortController.TryHandleSorting(
+                PilotBoard,
+                e.Column,
+                _currentRows,
+                PilotBoard.SelectedItem as PilotBoardRow,
+                out var sortMemberPath,
+                out var nextDirection))
             {
-                sortMemberPath = GetSortMemberPathFromColumn(e.Column);
-                if (string.IsNullOrWhiteSpace(sortMemberPath))
-                {
-                    return;
-                }
+                AppLogger.UiInfo($"Board sort changed. member='{sortMemberPath}' direction={nextDirection}");
             }
-
-            var nextDirection = _activeBoardSortMemberPath == sortMemberPath &&
-                                _activeBoardSortDirection == ListSortDirection.Ascending
-                ? ListSortDirection.Descending
-                : ListSortDirection.Ascending;
-
-            _activeBoardSortMemberPath = sortMemberPath;
-            _activeBoardSortDirection = nextDirection;
-
-            ApplySortIndicatorState(e.Column, nextDirection);
-            ApplyCurrentBoardOrdering();
-
-            AppLogger.UiInfo($"Board sort changed. member='{sortMemberPath}' direction={nextDirection}");
         }
 
         private void PilotBoard_MouseDoubleClick(object sender, MouseButtonEventArgs e)
@@ -2363,207 +2381,27 @@ namespace PitmastersGrill
 
         private void OpenDetailsWindow(PilotBoardRow row)
         {
-            var action = _pilotDetailWindowLifecycleController.DecideOpenAction(row.CharacterName);
-            if (action == PilotDetailWindowOpenAction.ActivateExisting)
-            {
-                _activePilotDetailWindow?.Activate();
-                return;
-            }
-
-            if (action == PilotDetailWindowOpenAction.ReplaceExisting)
-            {
-                CloseActiveDetailWindow();
-            }
-
-            _activePilotDetailWindow = new PilotDetailWindow(
-                row,
-                _pilotBoardRowDetailFormatter,
-                _notesRepository,
-                TryIgnoreForRow,
-                ToggleWatchForRow,
-                OpenZkillForRow)
-            {
-                Owner = this
-            };
-            _activePilotDetailWindow.ApplyThemeResources(Resources);
-            _activePilotDetailWindow.Topmost = Topmost;
-            PositionDetailWindow(_activePilotDetailWindow);
-            _activePilotDetailWindow.Closed += ActivePilotDetailWindow_Closed;
-            _pilotDetailWindowLifecycleController.MarkWindowOpened(row.CharacterName);
-            _activePilotDetailWindow.Show();
-            AppLogger.UiInfo($"Details window opened. character='{row.CharacterName}'");
-        }
-
-
-        private void PositionDetailWindow(PilotDetailWindow detailWindow)
-        {
-            if (detailWindow == null)
-            {
-                return;
-            }
-
-            detailWindow.WindowStartupLocation = WindowStartupLocation.Manual;
-
-            var detailWidth = detailWindow.Width > 0 ? detailWindow.Width : 430;
-            var detailHeight = detailWindow.Height > 0 ? detailWindow.Height : 360;
-            var ownerWidth = ActualWidth > 0 ? ActualWidth : Width;
-            var ownerHeight = ActualHeight > 0 ? ActualHeight : Height;
-            var ownerLeft = double.IsNaN(Left) ? 0 : Left;
-            var ownerTop = double.IsNaN(Top) ? 0 : Top;
-            var ownerHandle = new WindowInteropHelper(this).Handle;
-            var monitor = ownerHandle != IntPtr.Zero
-                ? FormsScreen.FromHandle(ownerHandle)
-                : FormsScreen.FromPoint(new System.Drawing.Point(
-                    (int)Math.Round(ownerLeft),
-                    (int)Math.Round(ownerTop)));
-
-            var presentationSource = PresentationSource.FromVisual(this);
-            var transformFromDevice = presentationSource?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
-            var workAreaPixels = monitor.WorkingArea;
-            var workTopLeft = transformFromDevice.Transform(new Point(workAreaPixels.Left, workAreaPixels.Top));
-            var workBottomRight = transformFromDevice.Transform(new Point(workAreaPixels.Right, workAreaPixels.Bottom));
-            var workLeft = workTopLeft.X;
-            var workTop = workTopLeft.Y;
-            var workRight = workBottomRight.X;
-            var workBottom = workBottomRight.Y;
-            var preferLeft = _settingsTabController.GetPilotDetailPlacementPreference(_appSettings) == PilotDetailPlacementPreference.AutoPreferLeft;
-            var placement = _pilotDetailWindowPlacementController.BuildPlacement(
-                detailWidth,
-                detailHeight,
-                ownerLeft,
-                ownerTop,
-                ownerWidth,
-                workLeft,
-                workTop,
-                workRight,
-                workBottom,
-                preferLeft,
-                DetailWindowGap);
-
-            detailWindow.Left = placement.Left;
-            detailWindow.Top = placement.Top;
-
-            if (placement.WasAdjusted)
-            {
-                AppLogger.UiInfo(
-                    $"Detail window placement adjusted. ownerBounds=({ownerLeft:0.##},{ownerTop:0.##},{ownerWidth:0.##},{ownerHeight:0.##}) workArea=({workLeft:0.##},{workTop:0.##},{workRight - workLeft:0.##},{workBottom - workTop:0.##}) preferredSide={placement.PreferredSide} finalSide={placement.FinalSide} finalBounds=({placement.Left:0.##},{placement.Top:0.##},{detailWidth:0.##},{detailHeight:0.##})");
-            }
-        }
-
-        private void ActivePilotDetailWindow_Closed(object? sender, EventArgs e)
-        {
-            if (_activePilotDetailWindow != null)
-            {
-                _activePilotDetailWindow.Closed -= ActivePilotDetailWindow_Closed;
-                _activePilotDetailWindow = null;
-            }
-
-            _pilotDetailWindowLifecycleController.ClearActiveWindow();
+            _pilotDetailSurface.OpenDetailsWindow(row);
         }
 
         private void CloseActiveDetailWindow()
         {
-            if (_activePilotDetailWindow == null)
-            {
-                return;
-            }
-
-            var window = _activePilotDetailWindow;
-            _activePilotDetailWindow = null;
-            window.Closed -= ActivePilotDetailWindow_Closed;
-            window.SaveCurrentState();
-            _pilotDetailWindowLifecycleController.ClearActiveWindow();
-            window.Close();
+            _pilotDetailSurface.CloseActiveDetailWindow();
         }
 
         private void ShowDetailPane(PilotBoardRow row)
         {
-            _detailPaneController.ShowDetailPane(
-                row,
-                DetailPane,
-                SelectedCharacterText,
-                FullCorpText,
-                FullAllianceText,
-                FreshnessText,
-                RecentPublicActivityText,
-                CynoSignalText,
-                CynoConfidenceBar,
-                CynoEvidenceText,
-                CynoLimitationsText,
-                ExplainabilityText,
-                NotesTagsBox,
-                KnownCynoOverrideCheckBox,
-                BaitOverrideCheckBox);
-
-            UpdateIgnoreAllianceButtonState(row);
-            UpdateWatchPilotDetailActionState(row);
+            _pilotDetailSurface.ShowDetailPane(row);
         }
 
         private void HideDetailPane()
         {
-            _detailPaneController.HideDetailPane(
-                DetailPane,
-                NotesTagsBox,
-                KnownCynoOverrideCheckBox,
-                BaitOverrideCheckBox);
-
-            if (ExplainabilityText != null)
-            {
-                ExplainabilityText.Text = "Explainability: --";
-            }
-
-            if (RecentPublicActivityText != null)
-            {
-                RecentPublicActivityText.Text = "Recent Public Kill/Loss Activity: --";
-            }
-
-            if (CynoSignalText != null)
-            {
-                CynoSignalText.Text = "Cyno Signal: Unknown";
-            }
-
-            if (CynoConfidenceBar != null)
-            {
-                CynoConfidenceBar.Value = 0;
-            }
-
-            if (CynoEvidenceText != null)
-            {
-                CynoEvidenceText.Text = "Evidence: --";
-            }
-
-            if (CynoLimitationsText != null)
-            {
-                CynoLimitationsText.Text = "Limitations: --";
-            }
-
-            UpdateIgnoreAllianceButtonState(null);
-            UpdateWatchPilotDetailActionState(null);
+            _pilotDetailSurface.HideDetailPane();
         }
 
         private void SaveCurrentNotesAndTags()
         {
-            if (_activePilotDetailWindow != null)
-            {
-                _activePilotDetailWindow.SaveCurrentState();
-                return;
-            }
-
-            if (_detailPaneController == null
-                || NotesTagsBox == null
-                || KnownCynoOverrideCheckBox == null
-                || BaitOverrideCheckBox == null
-                || PilotBoard == null)
-            {
-                AppLogger.UiWarn("Skipping notes/tag save because detail pane state was not fully initialized.");
-                return;
-            }
-
-            _detailPaneController.SaveCurrentNotesAndTags(
-                NotesTagsBox.Text,
-                KnownCynoOverrideCheckBox.IsChecked == true,
-                BaitOverrideCheckBox.IsChecked == true,
-                PilotBoard.SelectedItem as PilotBoardRow);
+            _pilotDetailSurface.SaveCurrentNotesAndTags(PilotBoard?.SelectedItem as PilotBoardRow);
         }
 
         private void IgnoreAllianceListView_IgnoreListChanged(object? sender, EventArgs e)
@@ -2574,15 +2412,9 @@ namespace PitmastersGrill
 
         private void IgnoreAllianceButton_Click(object sender, RoutedEventArgs e)
         {
-            var selectedRow = GetSelectedOrDisplayedDetailRow();
-
-            if (selectedRow == null)
-            {
-                AppLogger.UiWarn("Ignore alliance requested with no selected or displayed detail row.");
-                return;
-            }
-
-            TryIgnoreAllianceForRow(selectedRow);
+            _pilotDetailSurface.TryIgnoreAllianceForSelectedOrDisplayedRow(
+                PilotBoard?.SelectedItem as PilotBoardRow,
+                _currentRows);
         }
 
         private bool TryIgnoreAllianceForRow(PilotBoardRow selectedRow)
@@ -2624,52 +2456,19 @@ namespace PitmastersGrill
 
         private PilotBoardRow? GetSelectedOrDisplayedDetailRow()
         {
-            return _detailPaneController.GetSelectedOrDisplayedDetailRow(
-                PilotBoard.SelectedItem as PilotBoardRow,
-                DetailPane.Visibility,
-                SelectedCharacterText.Text,
+            return _pilotDetailSurface.GetSelectedOrDisplayedDetailRow(
+                PilotBoard?.SelectedItem as PilotBoardRow,
                 _currentRows);
-        }
-
-        private bool IsRowDisplayedInDetailPane(PilotBoardRow row)
-        {
-            return _detailPaneController.IsRowDisplayedInDetailPane(
-                row,
-                PilotBoard.SelectedItem as PilotBoardRow,
-                DetailPane.Visibility,
-                SelectedCharacterText.Text);
         }
 
         private void UpdateIgnoreAllianceButtonState(PilotBoardRow? row)
         {
-            if (IgnoreAllianceButton == null)
-            {
-                return;
-            }
-
-            var allianceId = _pilotDetailActionsPresenter.TryGetAllianceId(row?.AllianceId);
-            var state = _pilotDetailActionsPresenter.BuildIgnoreAllianceActionState(
-                row,
-                allianceId.HasValue && _ignoreAllianceCoordinator.ContainsAllianceId(allianceId.Value));
-
-            IgnoreAllianceButton.IsEnabled = state.IsEnabled;
-            IgnoreAllianceButton.ToolTip = state.ToolTip;
+            _pilotDetailSurface.UpdateIgnoreAllianceButtonState(row);
         }
 
         private void UpdateWatchPilotDetailActionState(PilotBoardRow? row)
         {
-            if (WatchPilotDetailAction == null)
-            {
-                return;
-            }
-
-            var state = _pilotDetailActionsPresenter.BuildWatchPilotActionState(row);
-            WatchPilotDetailAction.IsEnabled = state.IsEnabled;
-            WatchPilotDetailAction.Content = state.Content;
-            WatchPilotDetailAction.ToolTip = state.ToolTip;
-            WatchPilotDetailAction.SetResourceReference(
-                Control.ForegroundProperty,
-                state.ForegroundResourceKey);
+            _pilotDetailSurface.UpdateWatchPilotDetailActionState(row);
         }
 
         private void UpdateOpenDetailsButtonState()
@@ -2802,226 +2601,26 @@ namespace PitmastersGrill
 
         private void ToggleWatchForRow(PilotBoardRow row)
         {
-            var pilotId = _pilotDetailActionsPresenter.TryGetPilotId(row.CharacterId);
-            if (!pilotId.HasValue)
-            {
-                UpdateWatchPilotDetailActionState(row);
-                AppLogger.UiWarn($"Watch requested without a valid pilot ID. character='{row.CharacterName}'");
-                return;
-            }
-
-            var newWatchedState = !row.IsWatched;
-            if (!_watchedPilotRepository.SetWatched(row.CharacterId, newWatchedState))
-            {
-                UpdateWatchPilotDetailActionState(row);
-                AppLogger.UiWarn($"Watch state change failed. character='{row.CharacterName}' characterId='{row.CharacterId}'");
-                return;
-            }
-
-            row.IsWatched = newWatchedState;
-            ApplyCurrentBoardOrdering();
-            UpdateWatchPilotDetailActionState(row);
-            RefreshDetailWindowIfSelected(row);
-
-            AppLogger.UiInfo(
-                $"Watch state changed. character='{row.CharacterName}' characterId='{row.CharacterId}' watched={row.IsWatched}");
+            _pilotDetailSurface.ToggleWatchForRow(row);
         }
 
         private void ApplyCurrentBoardOrdering()
         {
-            if (_currentRows.Count <= 1)
-            {
-                return;
-            }
-
-            var selectedRow = PilotBoard.SelectedItem as PilotBoardRow;
-            var baseOrderIndexes = _currentRows
-                .Select((row, index) => new KeyValuePair<PilotBoardRow, int>(row, index))
-                .ToDictionary(pair => pair.Key, pair => pair.Value);
-
-            var reorderedRows = _currentRows
-                .OrderBy(row => row, Comparer<PilotBoardRow>.Create((leftRow, rightRow) =>
-                    CompareBoardRows(
-                        leftRow,
-                        baseOrderIndexes[leftRow],
-                        rightRow,
-                        baseOrderIndexes[rightRow])))
-                .ToList();
-
-            var changed = false;
-            for (var index = 0; index < reorderedRows.Count; index++)
-            {
-                if (!ReferenceEquals(_currentRows[index], reorderedRows[index]))
+            _boardSortController.ApplyCurrentBoardOrdering(
+                _currentRows,
+                PilotBoard?.SelectedItem as PilotBoardRow,
+                row =>
                 {
-                    changed = true;
-                    break;
-                }
-            }
-
-            if (!changed)
-            {
-                return;
-            }
-
-            _currentRows.Clear();
-            foreach (var row in reorderedRows)
-            {
-                _currentRows.Add(row);
-            }
-
-            if (selectedRow != null && _currentRows.Contains(selectedRow))
-            {
-                PilotBoard.SelectedItem = selectedRow;
-            }
-        }
-
-        private int CompareBoardRows(PilotBoardRow leftRow, int leftIndex, PilotBoardRow rightRow, int rightIndex)
-        {
-            var watchedCompare = Comparer<bool>.Default.Compare(rightRow.IsWatched, leftRow.IsWatched);
-            if (watchedCompare != 0)
-            {
-                return watchedCompare;
-            }
-
-            if (!string.IsNullOrWhiteSpace(_activeBoardSortMemberPath) && _activeBoardSortDirection.HasValue)
-            {
-                var valueCompare = CompareSortValues(
-                    GetBoardSortValue(leftRow, _activeBoardSortMemberPath),
-                    GetBoardSortValue(rightRow, _activeBoardSortMemberPath));
-
-                if (valueCompare != 0)
-                {
-                    return _activeBoardSortDirection == ListSortDirection.Descending
-                        ? -valueCompare
-                        : valueCompare;
-                }
-            }
-
-            return leftIndex.CompareTo(rightIndex);
-        }
-
-        private static int CompareSortValues(object? leftValue, object? rightValue)
-        {
-            if (leftValue == null && rightValue == null)
-            {
-                return 0;
-            }
-
-            if (leftValue == null)
-            {
-                return -1;
-            }
-
-            if (rightValue == null)
-            {
-                return 1;
-            }
-
-            if (leftValue is string leftString && rightValue is string rightString)
-            {
-                return StringComparer.OrdinalIgnoreCase.Compare(leftString, rightString);
-            }
-
-            if (leftValue is IComparable comparable)
-            {
-                try
-                {
-                    return comparable.CompareTo(rightValue);
-                }
-                catch (ArgumentException)
-                {
-                    return StringComparer.OrdinalIgnoreCase.Compare(
-                        leftValue.ToString(),
-                        rightValue.ToString());
-                }
-            }
-
-            return StringComparer.OrdinalIgnoreCase.Compare(
-                leftValue.ToString(),
-                rightValue.ToString());
-        }
-
-        private static object? GetBoardSortValue(PilotBoardRow row, string? sortMemberPath)
-        {
-            if (row == null || string.IsNullOrWhiteSpace(sortMemberPath))
-            {
-                return null;
-            }
-
-            return sortMemberPath switch
-            {
-                nameof(PilotBoardRow.CharacterName) => row.CharacterName,
-                nameof(PilotBoardRow.AllianceNameDisplay) => row.AllianceNameDisplay,
-                nameof(PilotBoardRow.CorpNameDisplay) => row.CorpNameDisplay,
-                nameof(PilotBoardRow.KillCount) => row.KillCount,
-                nameof(PilotBoardRow.LossCount) => row.LossCount,
-                nameof(PilotBoardRow.AvgAttackersWhenAttacking) => row.AvgAttackersWhenAttacking,
-                nameof(PilotBoardRow.LastShipSeenName) => row.LastShipSeenName,
-                nameof(PilotBoardRow.LastShipSeenDateDisplay) => row.LastShipSeenAtUtc,
-                nameof(PilotBoardRow.LastShipSeenAtUtc) => row.LastShipSeenAtUtc,
-                nameof(PilotBoardRow.LastPublicCynoCapableHull) => row.LastPublicCynoCapableHull,
-                _ => GetBoardSortValueByReflection(row, sortMemberPath)
-            };
-        }
-
-        private static object? GetBoardSortValueByReflection(PilotBoardRow row, string sortMemberPath)
-        {
-            var property = typeof(PilotBoardRow).GetProperty(sortMemberPath);
-            return property?.GetValue(row);
+                    if (PilotBoard != null)
+                    {
+                        PilotBoard.SelectedItem = row;
+                    }
+                });
         }
 
         private void ResetManualBoardSort()
         {
-            _activeBoardSortMemberPath = nameof(PilotBoardRow.CharacterName);
-            _activeBoardSortDirection = ListSortDirection.Ascending;
-
-            if (CharacterColumn != null)
-            {
-                ApplySortIndicatorState(CharacterColumn, ListSortDirection.Ascending);
-                return;
-            }
-
-            ClearBoardSortIndicators();
-        }
-
-        private void ApplySortIndicatorState(DataGridColumn activeColumn, ListSortDirection direction)
-        {
-            if (PilotBoard == null)
-            {
-                return;
-            }
-
-            foreach (var column in PilotBoard.Columns)
-            {
-                column.SortDirection = ReferenceEquals(column, activeColumn)
-                    ? direction
-                    : null;
-            }
-        }
-
-        private void ClearBoardSortIndicators()
-        {
-            if (PilotBoard == null)
-            {
-                return;
-            }
-
-            foreach (var column in PilotBoard.Columns)
-            {
-                column.SortDirection = null;
-            }
-        }
-
-        private static string? GetSortMemberPathFromColumn(DataGridColumn column)
-        {
-            if (column is DataGridBoundColumn boundColumn &&
-                boundColumn.Binding is Binding binding &&
-                binding.Path != null)
-            {
-                return binding.Path.Path;
-            }
-
-            return null;
+            _boardSortController.ResetManualBoardSort(PilotBoard, CharacterColumn);
         }
 
         private long? GetIgnoreId(PilotBoardRow row, IgnoreEntryType type)
@@ -3098,85 +2697,6 @@ namespace PitmastersGrill
         private void UpdateAnalysisTab()
         {
             _analysisTabPresenter.UpdateAnalysisTab(_currentRows);
-        }
-
-        private bool IsSessionContextStale()
-        {
-            return _eveSessionContextCoordinator.IsStale(
-                _currentEveSessionContext,
-                _lastSessionContextRefreshUtc,
-                DateTime.UtcNow);
-        }
-
-        private void TriggerSessionContextRefresh(string reason, bool force)
-        {
-            if (!_eveSessionContextCoordinator.ShouldTriggerRefresh(
-                _isShuttingDown,
-                force,
-                _currentEveSessionContext,
-                _lastSessionContextRefreshUtc,
-                _isSessionContextRefreshInFlight,
-                DateTime.UtcNow))
-            {
-                return;
-            }
-
-            _ = RefreshSessionContextAsync(reason);
-        }
-
-        private async Task RefreshSessionContextAsync(string reason)
-        {
-            if (_isSessionContextRefreshInFlight || _isShuttingDown)
-            {
-                return;
-            }
-
-            _isSessionContextRefreshInFlight = true;
-            try
-            {
-                AppLogger.UiDebug($"EVE session context refresh started. reason='{reason}'");
-                var context = await _eveSessionContextService.CaptureAsync(_windowShutdownCts.Token);
-                _lastSessionContextRefreshUtc = DateTime.UtcNow;
-                _currentEveSessionContext = context;
-
-                await Dispatcher.InvokeAsync(() => ApplyEveSessionContext(context));
-            }
-            catch (OperationCanceledException)
-            {
-                // Shutdown or refresh cancellation is expected.
-            }
-            catch (Exception ex)
-            {
-                AppLogger.UiWarn($"EVE session context refresh failed. reason='{reason}' message={ex.Message}");
-                var fallback = _eveSessionContextCoordinator.CreateFallbackContext();
-
-                _lastSessionContextRefreshUtc = DateTime.UtcNow;
-                _currentEveSessionContext = fallback;
-                await Dispatcher.InvokeAsync(() => ApplyEveSessionContext(fallback));
-            }
-            finally
-            {
-                _isSessionContextRefreshInFlight = false;
-            }
-        }
-
-        private void ApplyEveSessionContext(EveSessionContext context)
-        {
-            if (AnalysisCurrentCharacterText == null ||
-                AnalysisCurrentSystemText == null ||
-                AnalysisEvidenceSourceText == null ||
-                AnalysisObservedAtText == null ||
-                AnalysisContextStatusText == null)
-            {
-                return;
-            }
-
-            var projection = _eveSessionContextCoordinator.BuildProjection(context);
-            AnalysisCurrentCharacterText.Text = projection.CharacterText;
-            AnalysisCurrentSystemText.Text = projection.SystemText;
-            AnalysisEvidenceSourceText.Text = projection.EvidenceSourceText;
-            AnalysisObservedAtText.Text = projection.ObservedAtText;
-            AnalysisContextStatusText.Text = projection.StatusText;
         }
 
         private void AnalysisHyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/PitmastersGrill/MainWindow.xaml.cs
+++ b/PitmastersGrill/MainWindow.xaml.cs
@@ -80,16 +80,10 @@ namespace PitmastersGrill
         private readonly ZkillUrlBuilder _zkillUrlBuilder;
         private readonly BrowserLauncher _browserLauncher;
         private ManualUpdateCheckController? _manualUpdateCheckController;
-        private DiagnosticsActionController? _diagnosticsActionController;
+        private readonly DiagnosticsSupportSurface _diagnosticsSupportSurface = null!;
         private readonly EveSessionContextService _eveSessionContextService;
         private readonly MainWindowDiagnostics _diagnostics;
-        private readonly IntelUpdateBannerController _intelUpdateBannerController;
-        private readonly IntelStatusDetailsPresenter _intelStatusDetailsPresenter;
-        private readonly IntelActionsController _intelActionsController = null!;
-        private readonly IntelMaintenanceActionsController _intelMaintenanceActionsController = null!;
-        private readonly ProviderHealthPresenter _providerHealthPresenter;
-        private readonly DiagnosticsCacheStatsPresenter _diagnosticsCacheStatsPresenter;
-        private readonly DiagnosticsCacheMaintenanceController _diagnosticsCacheMaintenanceController = null!;
+        private readonly IntelSupportSurface _intelSupportSurface = null!;
         private readonly PilotDetailActionsPresenter _pilotDetailActionsPresenter;
         private readonly PilotDetailWindowPlacementController _pilotDetailWindowPlacementController;
         private readonly PilotDetailWindowLifecycleController _pilotDetailWindowLifecycleController;
@@ -197,54 +191,6 @@ namespace PitmastersGrill
                 Interval = TimeSpan.FromMilliseconds(BoardModeHintMilliseconds)
             };
             _boardModeHintTimer.Tick += BoardModeHintTimer_Tick;
-            _intelUpdateBannerController = new IntelUpdateBannerController(Dispatcher);
-            _providerHealthPresenter = new ProviderHealthPresenter();
-            _diagnosticsCacheStatsPresenter = new DiagnosticsCacheStatsPresenter();
-            _intelStatusDetailsPresenter = new IntelStatusDetailsPresenter(
-                IntelSupportViewControl.IntelLastUpdatedTextBlock,
-                IntelSupportViewControl.IntelOldestKillmailDayTextBlock,
-                IntelSupportViewControl.IntelNewestKillmailDayTextBlock,
-                IntelSupportViewControl.IntelCurrentUpdateStatusTextBlock,
-                IntelSupportViewControl.IntelTotalProgressBarControl,
-                IntelSupportViewControl.IntelTotalProgressTextBlock,
-                IntelSupportViewControl.IntelCurrentDayProgressBarControl,
-                IntelSupportViewControl.IntelCurrentDayProgressTextBlock,
-                IntelSupportViewControl.IntelLiveFeedSourceTextBlock,
-                IntelSupportViewControl.IntelLiveFeedStatusTextBlock,
-                IntelSupportViewControl.IntelLiveFeedEnabledTextBlock,
-                IntelSupportViewControl.IntelLiveFeedRecentImportsTextBlock,
-                IntelSupportViewControl.IntelLiveFeedNextSequenceTextBlock,
-                IntelSupportViewControl.IntelLiveFeedLastProcessedSequenceTextBlock,
-                IntelSupportViewControl.IntelLiveFeedLastSuccessTextBlock,
-                IntelSupportViewControl.IntelLiveFeedLastCaughtUpTextBlock,
-                IntelSupportViewControl.IntelLiveFeedLastErrorTextBlock,
-                IntelSupportViewControl.TodaysFreshnessStatusTextBlock,
-                IntelSupportViewControl.TodaysFreshnessVisiblePilotsTextBlock,
-                IntelSupportViewControl.TodaysFreshnessEntitiesQueriedTextBlock,
-                IntelSupportViewControl.TodaysFreshnessResultsFoundTextBlock,
-                IntelSupportViewControl.TodaysFreshnessKnownSkippedTextBlock,
-                IntelSupportViewControl.TodaysFreshnessImportedTextBlock,
-                IntelSupportViewControl.TodaysFreshnessFailedTextBlock,
-                IntelSupportViewControl.TodaysFreshnessLastRunTextBlock,
-                IntelSupportViewControl.TodaysFreshnessDetailTextBlock,
-                IntelSupportViewControl.TodaysFreshnessLastErrorTextBlock,
-                IntelSupportViewControl.RunTodaysFreshnessButtonControl,
-                IntelSupportViewControl.HistoricalFreshnessStatusTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessModeTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessVisiblePilotsTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessCandidatesConsideredTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessCandidatesSkippedCooldownTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessPilotsCheckedTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessDaysCheckedTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessEntitiesQueriedTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessResultsFoundTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessKnownSkippedTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessImportedTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessFailedTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessLastRunTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessDetailTextBlock,
-                IntelSupportViewControl.HistoricalFreshnessLastErrorTextBlock,
-                IntelSupportViewControl.RunHistoricalFreshnessButtonControl);
             _boardPopulationTimingMarkerTracker = new BoardPopulationTimingMarkerTracker();
 
             AppLogger.UiInfo("MainWindow InitializeComponent complete.");
@@ -321,12 +267,22 @@ namespace PitmastersGrill
                 _appSettings,
                 _windowShutdownCts.Token,
                 () => _isShuttingDown);
-            _diagnosticsActionController = new DiagnosticsActionController(
+            _diagnosticsSupportSurface = DiagnosticsSupportSurface.Create(
                 this,
-                DiagnosticsSupportViewControl.DiagnosticsStatusTextBlock,
-                _browserLauncher);
-            _intelActionsController = new IntelActionsController(
+                DiagnosticsSupportViewControl,
+                _browserLauncher,
+                _providerHealthRows,
+                () => _boardPopulationEntryController.IsClipboardProcessing,
+                (message, title, buttons, image) => MessageBox.Show(this, message, title, buttons, image),
+                DiagnosticTelemetry.GetProviderHealthSnapshots,
+                _cacheMaintenanceService.GetStats,
+                _cacheMaintenanceService.ClearExpired,
+                _cacheMaintenanceService.Vacuum,
+                _cacheMaintenanceService.ClearAll);
+            _intelSupportSurface = IntelSupportSurface.Create(
                 this,
+                Dispatcher,
+                IntelSupportViewControl,
                 _backgroundIntelUpdateService,
                 _settingsTabController,
                 () => _appSettings,
@@ -335,32 +291,16 @@ namespace PitmastersGrill
                 () => _isShuttingDown,
                 _windowShutdownCts.Token,
                 () => _currentRows.ToList(),
-                RefreshCurrentBoardRowsFromLocalIntelAsync);
-            _intelMaintenanceActionsController = new IntelMaintenanceActionsController(
+                RefreshCurrentBoardRowsFromLocalIntelAsync,
                 () => _boardPopulationEntryController.IsClipboardProcessing,
                 SetDiagnosticsStatus,
                 enabled => DiagnosticsSupportViewControl.SetRebuildKillmailDerivedIntelEnabled(enabled),
-                enabled => IntelSupportViewControl.EnableKillmailDbPullButtonControl.IsEnabled = enabled,
                 () => _mainWindowAppearanceController.GetMaxKillmailAgeDaysSettingValue(_appSettings),
-                () => _isShuttingDown,
-                _windowShutdownCts.Token,
                 cancellationToken => _killmailDerivedIntelRebuildService.RebuildConfirmedCynoModuleObservationsAsync(cancellationToken),
                 (seedDays, cancellationToken) => _backgroundIntelUpdateService.EnableKillmailDbPullAsync(seedDays, cancellationToken),
                 RefreshCacheStatsUi,
                 RefreshConfirmedCynoModuleStateForCurrentRows,
                 (message, title, buttons, image) => MessageBox.Show(this, message, title, buttons, image));
-            _diagnosticsCacheMaintenanceController = new DiagnosticsCacheMaintenanceController(
-                () => _boardPopulationEntryController.IsClipboardProcessing,
-                SetDiagnosticsStatus,
-                (message, title, buttons, image) => MessageBox.Show(this, message, title, buttons, image),
-                () => DiagnosticTelemetry.GetProviderHealthSnapshots(),
-                snapshots => _providerHealthPresenter.ApplySnapshots(_providerHealthRows, snapshots),
-                () => _cacheMaintenanceService.GetStats(),
-                () => _cacheMaintenanceService.ClearExpired(),
-                () => _cacheMaintenanceService.Vacuum(),
-                () => _cacheMaintenanceService.ClearAll(),
-                _diagnosticsCacheStatsPresenter,
-                text => DiagnosticsSupportViewControl.SetCacheStatsText(text));
             _mainWindowAppearanceController.ApplyPanelModeShell(this, _appSettings, Resources);
             CompactModeToggleButton.IsChecked = _appSettings.CompactModeEnabled;
 
@@ -414,7 +354,7 @@ namespace PitmastersGrill
             ApplyCompactModeUi();
             UpdateBoardSummaryBanner();
             UpdateAnalysisTab();
-            ApplyIntelUpdateSnapshot(_backgroundIntelUpdateService.GetSnapshot());
+            _intelSupportSurface.ApplySnapshot(_backgroundIntelUpdateService.GetSnapshot(), _isShuttingDown);
             ApplyEveSessionContext(_eveSessionContextCoordinator.CreatePendingContext());
             _isMainWindowInitialized = true;
 
@@ -1325,41 +1265,7 @@ namespace PitmastersGrill
 
         private void OnIntelUpdateStatusChanged(IntelUpdateStatusSnapshot snapshot)
         {
-            _intelUpdateBannerController.HandleStatusChanged(
-                snapshot,
-                IntelSupportViewControl.IntelUpdateBannerControl,
-                IntelSupportViewControl.IntelUpdateStatusTextBlock,
-                IntelSupportViewControl.IntelUpdateDetailTextBlock);
-
-            if (Dispatcher.CheckAccess())
-            {
-                ApplyIntelStatusDetails(snapshot);
-            }
-            else
-            {
-                Dispatcher.Invoke(() => ApplyIntelStatusDetails(snapshot));
-            }
-        }
-
-        private void ApplyIntelUpdateSnapshot(IntelUpdateStatusSnapshot snapshot)
-        {
-            _intelUpdateBannerController.ApplySnapshot(
-                snapshot,
-                IntelSupportViewControl.IntelUpdateBannerControl,
-                IntelSupportViewControl.IntelUpdateStatusTextBlock,
-                IntelSupportViewControl.IntelUpdateDetailTextBlock);
-
-            ApplyIntelStatusDetails(snapshot);
-        }
-
-        private void ApplyIntelStatusDetails(IntelUpdateStatusSnapshot snapshot)
-        {
-            if (snapshot == null)
-            {
-                return;
-            }
-            var projection = IntelStatusDetailsProjection.Create(snapshot, _isShuttingDown);
-            _intelStatusDetailsPresenter.Apply(projection);
+            _intelSupportSurface.HandleStatusChanged(snapshot, _isShuttingDown);
         }
 
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
@@ -2218,7 +2124,7 @@ namespace PitmastersGrill
 
         private async void EnableKillmailDbPullButton_Click(object sender, RoutedEventArgs e)
         {
-            await _intelMaintenanceActionsController.RunEnableKillmailDbPullAsync();
+            await _intelSupportSurface.RunEnableKillmailDbPullAsync();
         }
 
 
@@ -2234,62 +2140,62 @@ namespace PitmastersGrill
 
         private void OpenLogsButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsActionController?.OpenLogs();
+            _diagnosticsSupportSurface.OpenLogs();
         }
 
         private void PackageDiagnosticsButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsActionController?.PackageDiagnostics();
+            _diagnosticsSupportSurface.PackageDiagnostics();
         }
 
         private void OpenDiagnosticsFolderButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsActionController?.OpenDiagnosticsFolder();
+            _diagnosticsSupportSurface.OpenDiagnosticsFolder();
         }
 
         private void SetDiagnosticsStatus(string message)
         {
-            _diagnosticsActionController?.SetStatus(message);
+            _diagnosticsSupportSurface.SetStatus(message);
         }
 
         private void RefreshProviderHealthButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsCacheMaintenanceController.RefreshProviderHealth();
+            _diagnosticsSupportSurface.RefreshProviderHealth();
         }
 
         private void RefreshProviderHealthUi()
         {
-            _diagnosticsCacheMaintenanceController.RefreshProviderHealthUi();
+            _diagnosticsSupportSurface.RefreshProviderHealthUi();
         }
 
         private void RefreshCacheStatsButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsCacheMaintenanceController.RefreshCacheStats();
+            _diagnosticsSupportSurface.RefreshCacheStats();
         }
 
         private void ClearExpiredCacheButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsCacheMaintenanceController.ClearExpiredCache();
+            _diagnosticsSupportSurface.ClearExpiredCache();
         }
 
         private void VacuumCacheButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsCacheMaintenanceController.VacuumCache();
+            _diagnosticsSupportSurface.VacuumCache();
         }
 
         private void ClearAllCacheButton_Click(object sender, RoutedEventArgs e)
         {
-            _diagnosticsCacheMaintenanceController.ClearAllCache();
+            _diagnosticsSupportSurface.ClearAllCache();
         }
 
         private async void RebuildKillmailDerivedIntelButton_Click(object sender, RoutedEventArgs e)
         {
-            await _intelMaintenanceActionsController.RunRebuildKillmailDerivedIntelAsync();
+            await _intelSupportSurface.RunRebuildKillmailDerivedIntelAsync();
         }
 
         private void RefreshCacheStatsUi()
         {
-            _diagnosticsCacheMaintenanceController.RefreshCacheStatsUi();
+            _diagnosticsSupportSurface.RefreshCacheStatsUi();
         }
 
 
@@ -2330,7 +2236,7 @@ namespace PitmastersGrill
         private async void EnableLiveZkillFeedCheckBox_Checked(object sender, RoutedEventArgs e)
         {
             var enabled = IntelSupportViewControl.EnableLiveZkillFeedCheckBoxControl.IsChecked == true;
-            await _intelActionsController.HandleLiveFeedToggleAsync(enabled);
+            await _intelSupportSurface.HandleLiveFeedToggleAsync(enabled);
         }
 
         private void BackgroundHistoricalRepairEnabledCheckBox_Checked(object sender, RoutedEventArgs e)
@@ -2343,17 +2249,17 @@ namespace PitmastersGrill
 
         private async void RunTodaysFreshnessButton_Click(object sender, RoutedEventArgs e)
         {
-            await _intelActionsController.RunTodaysFreshnessAsync();
+            await _intelSupportSurface.RunTodaysFreshnessAsync();
         }
 
         private async void RunHistoricalFreshnessButton_Click(object sender, RoutedEventArgs e)
         {
-            await _intelActionsController.RunHistoricalFreshnessAsync();
+            await _intelSupportSurface.RunHistoricalFreshnessAsync();
         }
 
         public List<long> GetVisibleCharacterIdsForBackgroundHistoricalRepair()
         {
-            return _intelActionsController.GetVisibleCharacterIdsForBackgroundHistoricalRepair();
+            return _intelSupportSurface.GetVisibleCharacterIdsForBackgroundHistoricalRepair();
         }
 
         private async Task RefreshCurrentBoardRowsFromLocalIntelAsync(string reason)

--- a/PitmastersGrill/Services/BoardPopulationSurface.cs
+++ b/PitmastersGrill/Services/BoardPopulationSurface.cs
@@ -1,0 +1,236 @@
+using PitmastersGrill.Diagnostics;
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Threading;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class BoardPopulationSurface
+    {
+        private readonly BoardPopulationEntryController _boardPopulationEntryController;
+        private readonly BoardPopulationPassController _boardPopulationPassController;
+        private readonly BoardPopulationRetryController _boardPopulationRetryController;
+        private readonly MainWindowDiagnostics _diagnostics;
+
+        public BoardPopulationSurface(
+            BoardPopulationEntryController boardPopulationEntryController,
+            BoardPopulationPassController boardPopulationPassController,
+            BoardPopulationRetryController boardPopulationRetryController,
+            MainWindowDiagnostics diagnostics)
+        {
+            _boardPopulationEntryController = boardPopulationEntryController ?? throw new ArgumentNullException(nameof(boardPopulationEntryController));
+            _boardPopulationPassController = boardPopulationPassController ?? throw new ArgumentNullException(nameof(boardPopulationPassController));
+            _boardPopulationRetryController = boardPopulationRetryController ?? throw new ArgumentNullException(nameof(boardPopulationRetryController));
+            _diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        public void ScheduleClipboardProcessing(
+            DispatcherTimer clipboardDebounceTimer,
+            int clipboardDebounceMilliseconds)
+        {
+            clipboardDebounceTimer.Stop();
+            clipboardDebounceTimer.Start();
+            _diagnostics.ClipboardChangeDebounced(clipboardDebounceMilliseconds);
+        }
+
+        public Task ProcessClipboardIfValidAsync(
+            Func<bool> clipboardContainsText,
+            Func<string> clipboardGetText,
+            Action<bool> setBoardButtonsEnabled,
+            Func<IDisposable> beginForegroundPriority,
+            Action cancelBoardPopulationRetry,
+            Action<bool> resetBoardPopulationTracking,
+            Action<string, BoardPopulationStatusKind> updateClipboardStatus,
+            Func<List<string>, bool, Task> processNamesAsync)
+        {
+            return _boardPopulationEntryController.ProcessClipboardIfValidAsync(
+                clipboardContainsText,
+                clipboardGetText,
+                setBoardButtonsEnabled,
+                beginForegroundPriority,
+                cancelBoardPopulationRetry,
+                resetBoardPopulationTracking,
+                updateClipboardStatus,
+                processNamesAsync);
+        }
+
+        public Task ProcessNamesAsync(
+            List<string> characterNames,
+            bool isRetryPass,
+            Action<string, bool> triggerSessionContextRefresh,
+            Action saveCurrentNotesAndTags,
+            Action<List<string>, Dictionary<string, ResolverCacheEntry>, Dictionary<string, StatsCacheEntry>> buildInitialBoard,
+            Func<int> beginProcessingGeneration,
+            Func<int> getCurrentGeneration,
+            Func<int> getCurrentRowCount,
+            Func<int, Task> processCurrentRowsAsync,
+            Action<string, BoardPopulationStatusKind> updateBoardPopulationStatus,
+            Action updateLastRefreshed,
+            Action<int> finalizeBoardPopulationPass)
+        {
+            triggerSessionContextRefresh(
+                isRetryPass ? "board retry pass" : "accepted local clipboard",
+                !isRetryPass);
+
+            return _boardPopulationEntryController.ProcessNamesAsync(
+                characterNames,
+                isRetryPass,
+                saveCurrentNotesAndTags,
+                buildInitialBoard,
+                beginProcessingGeneration,
+                getCurrentGeneration,
+                getCurrentRowCount,
+                processCurrentRowsAsync,
+                updateBoardPopulationStatus,
+                updateLastRefreshed,
+                finalizeBoardPopulationPass);
+        }
+
+        public void FinalizeBoardPopulationPass(
+            int generation,
+            int currentGeneration,
+            IReadOnlyCollection<PilotBoardRow> currentRows,
+            int maxBoardPopulationRetryAttempts,
+            Action<string, BoardPopulationStatusKind> updateBoardPopulationStatus,
+            Action scheduleBoardPopulationRetry)
+        {
+            if (generation != currentGeneration)
+            {
+                _diagnostics.FinalizeSkipped(generation, currentGeneration);
+                return;
+            }
+
+            var decision = _boardPopulationPassController.BuildFinalizeDecision(
+                currentRows,
+                _boardPopulationRetryController.RetryAttempt,
+                maxBoardPopulationRetryAttempts);
+
+            if (decision.IsComplete)
+            {
+                _boardPopulationRetryController.MarkComplete();
+
+                _diagnostics.BoardProcessFinalizedComplete(
+                    generation,
+                    decision.CompleteCount,
+                    decision.PartialCount,
+                    decision.RetryableCount);
+
+                updateBoardPopulationStatus(decision.StatusText, decision.StatusKind);
+                return;
+            }
+
+            _boardPopulationRetryController.MarkIncomplete();
+            _boardPopulationEntryController.InvalidateLastProcessedClipboard();
+
+            if (decision.RetryLimitReached)
+            {
+                _diagnostics.BoardProcessRetryLimitReached(
+                    generation,
+                    decision.RetryableCount,
+                    decision.PartialCount,
+                    _boardPopulationRetryController.RetryAttempt);
+
+                updateBoardPopulationStatus(decision.StatusText, decision.StatusKind);
+                return;
+            }
+
+            _diagnostics.BoardProcessRequiresRetry(
+                generation,
+                decision.RetryableCount,
+                decision.PartialCount,
+                _boardPopulationRetryController.RetryAttempt);
+
+            updateBoardPopulationStatus(decision.StatusText, decision.StatusKind);
+
+            if (decision.ShouldScheduleRetry)
+            {
+                scheduleBoardPopulationRetry();
+            }
+        }
+
+        public void ScheduleBoardPopulationRetry(
+            IReadOnlyCollection<PilotBoardRow> currentRows,
+            Dispatcher dispatcher,
+            Action<string, BoardPopulationStatusKind> updateBoardPopulationStatus,
+            Func<Task> processRetryPassAsync)
+        {
+            _boardPopulationRetryController.ScheduleRetry(
+                currentRows,
+                dispatcher,
+                updateBoardPopulationStatus,
+                processRetryPassAsync);
+        }
+
+        public Task ProcessRetryPassAsync(
+            IReadOnlyCollection<PilotBoardRow> currentRows,
+            Func<IDisposable> beginForegroundPriority,
+            Func<IReadOnlyCollection<PilotBoardRow>, int, Task> processRowBatchAsync,
+            Func<int> getProcessingGeneration,
+            Action updateLastRefreshed,
+            Action<int> finalizeBoardPopulationPass)
+        {
+            return _boardPopulationRetryController.ProcessRetryPassAsync(
+                currentRows,
+                beginForegroundPriority,
+                processRowBatchAsync,
+                getProcessingGeneration,
+                updateLastRefreshed,
+                finalizeBoardPopulationPass);
+        }
+
+        public void CancelBoardPopulationRetry()
+        {
+            _boardPopulationRetryController.CancelRetry();
+        }
+
+        public void ResetBoardPopulationTracking(bool preserveLastProcessedClipboardText = false)
+        {
+            _boardPopulationEntryController.ResetTracking(preserveLastProcessedClipboardText);
+            _boardPopulationRetryController.ResetTracking();
+        }
+
+        public void ClearBoard(
+            string reason,
+            ObservableCollection<PilotBoardRow> currentRows,
+            Action saveCurrentNotesAndTags,
+            Action cancelBoardPopulationRetry,
+            Action resetTracking,
+            Action resetManualBoardSort,
+            Action unsubscribeFromAllBoardRows,
+            Action recomputeCorpAllianceCounts,
+            Action closeActiveDetailWindow,
+            Action updateOpenDetailsButtonState,
+            Action updateLastRefreshed,
+            Action<string, BoardPopulationStatusKind> updateBoardPopulationStatus,
+            Action incrementProcessingGeneration)
+        {
+            var clearedRowCount = currentRows.Count;
+
+            _diagnostics.ClearBoardStart(clearedRowCount);
+
+            saveCurrentNotesAndTags();
+            cancelBoardPopulationRetry();
+            incrementProcessingGeneration();
+            resetTracking();
+            resetManualBoardSort();
+            unsubscribeFromAllBoardRows();
+
+            currentRows.Clear();
+            recomputeCorpAllianceCounts();
+            closeActiveDetailWindow();
+            updateOpenDetailsButtonState();
+
+            updateLastRefreshed();
+            updateBoardPopulationStatus("Board cleared", BoardPopulationStatusKind.Neutral);
+
+            AppLogger.UiInfo($"Board cleared. reason='{reason}' removedRows={clearedRowCount}");
+            _diagnostics.ClearBoardComplete();
+        }
+    }
+}

--- a/PitmastersGrill/Services/BoardSortController.cs
+++ b/PitmastersGrill/Services/BoardSortController.cs
@@ -1,0 +1,260 @@
+using PitmastersGrill.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class BoardSortController
+    {
+        private string? _activeBoardSortMemberPath = nameof(PilotBoardRow.CharacterName);
+        private ListSortDirection? _activeBoardSortDirection = ListSortDirection.Ascending;
+
+        public bool TryHandleSorting(
+            DataGrid? pilotBoard,
+            DataGridColumn? column,
+            ObservableCollection<PilotBoardRow> currentRows,
+            PilotBoardRow? selectedRow,
+            out string sortMemberPath,
+            out ListSortDirection nextDirection)
+        {
+            sortMemberPath = string.Empty;
+            nextDirection = ListSortDirection.Ascending;
+
+            if (pilotBoard == null || column == null)
+            {
+                return false;
+            }
+
+            sortMemberPath = column.SortMemberPath;
+            if (string.IsNullOrWhiteSpace(sortMemberPath))
+            {
+                sortMemberPath = GetSortMemberPathFromColumn(column) ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(sortMemberPath))
+                {
+                    return false;
+                }
+            }
+
+            nextDirection = _activeBoardSortMemberPath == sortMemberPath &&
+                            _activeBoardSortDirection == ListSortDirection.Ascending
+                ? ListSortDirection.Descending
+                : ListSortDirection.Ascending;
+
+            _activeBoardSortMemberPath = sortMemberPath;
+            _activeBoardSortDirection = nextDirection;
+
+            ApplySortIndicatorState(pilotBoard, column, nextDirection);
+            ApplyCurrentBoardOrdering(currentRows, selectedRow, row => pilotBoard.SelectedItem = row);
+            return true;
+        }
+
+        public void ApplyCurrentBoardOrdering(
+            ObservableCollection<PilotBoardRow> currentRows,
+            PilotBoardRow? selectedRow,
+            Action<PilotBoardRow?> restoreSelectedRow)
+        {
+            if (currentRows == null)
+            {
+                throw new ArgumentNullException(nameof(currentRows));
+            }
+
+            if (restoreSelectedRow == null)
+            {
+                throw new ArgumentNullException(nameof(restoreSelectedRow));
+            }
+
+            if (currentRows.Count <= 1)
+            {
+                return;
+            }
+
+            var baseOrderIndexes = currentRows
+                .Select((row, index) => new KeyValuePair<PilotBoardRow, int>(row, index))
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+
+            var reorderedRows = currentRows
+                .OrderBy(row => row, Comparer<PilotBoardRow>.Create((leftRow, rightRow) =>
+                    CompareBoardRows(
+                        leftRow,
+                        baseOrderIndexes[leftRow],
+                        rightRow,
+                        baseOrderIndexes[rightRow])))
+                .ToList();
+
+            var changed = false;
+            for (var index = 0; index < reorderedRows.Count; index++)
+            {
+                if (!ReferenceEquals(currentRows[index], reorderedRows[index]))
+                {
+                    changed = true;
+                    break;
+                }
+            }
+
+            if (!changed)
+            {
+                return;
+            }
+
+            currentRows.Clear();
+            foreach (var row in reorderedRows)
+            {
+                currentRows.Add(row);
+            }
+
+            if (selectedRow != null && currentRows.Contains(selectedRow))
+            {
+                restoreSelectedRow(selectedRow);
+            }
+        }
+
+        public void ResetManualBoardSort(DataGrid? pilotBoard, DataGridColumn? defaultColumn)
+        {
+            _activeBoardSortMemberPath = nameof(PilotBoardRow.CharacterName);
+            _activeBoardSortDirection = ListSortDirection.Ascending;
+
+            if (pilotBoard == null)
+            {
+                return;
+            }
+
+            if (defaultColumn != null)
+            {
+                ApplySortIndicatorState(pilotBoard, defaultColumn, ListSortDirection.Ascending);
+                return;
+            }
+
+            ClearBoardSortIndicators(pilotBoard);
+        }
+
+        private int CompareBoardRows(PilotBoardRow leftRow, int leftIndex, PilotBoardRow rightRow, int rightIndex)
+        {
+            var watchedCompare = Comparer<bool>.Default.Compare(rightRow.IsWatched, leftRow.IsWatched);
+            if (watchedCompare != 0)
+            {
+                return watchedCompare;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_activeBoardSortMemberPath) && _activeBoardSortDirection.HasValue)
+            {
+                var valueCompare = CompareSortValues(
+                    GetBoardSortValue(leftRow, _activeBoardSortMemberPath),
+                    GetBoardSortValue(rightRow, _activeBoardSortMemberPath));
+
+                if (valueCompare != 0)
+                {
+                    return _activeBoardSortDirection == ListSortDirection.Descending
+                        ? -valueCompare
+                        : valueCompare;
+                }
+            }
+
+            return leftIndex.CompareTo(rightIndex);
+        }
+
+        private static int CompareSortValues(object? leftValue, object? rightValue)
+        {
+            if (leftValue == null && rightValue == null)
+            {
+                return 0;
+            }
+
+            if (leftValue == null)
+            {
+                return -1;
+            }
+
+            if (rightValue == null)
+            {
+                return 1;
+            }
+
+            if (leftValue is string leftString && rightValue is string rightString)
+            {
+                return StringComparer.OrdinalIgnoreCase.Compare(leftString, rightString);
+            }
+
+            if (leftValue is IComparable comparable)
+            {
+                try
+                {
+                    return comparable.CompareTo(rightValue);
+                }
+                catch (ArgumentException)
+                {
+                    return StringComparer.OrdinalIgnoreCase.Compare(
+                        leftValue.ToString(),
+                        rightValue.ToString());
+                }
+            }
+
+            return StringComparer.OrdinalIgnoreCase.Compare(
+                leftValue.ToString(),
+                rightValue.ToString());
+        }
+
+        private static object? GetBoardSortValue(PilotBoardRow row, string? sortMemberPath)
+        {
+            if (row == null || string.IsNullOrWhiteSpace(sortMemberPath))
+            {
+                return null;
+            }
+
+            return sortMemberPath switch
+            {
+                nameof(PilotBoardRow.CharacterName) => row.CharacterName,
+                nameof(PilotBoardRow.AllianceNameDisplay) => row.AllianceNameDisplay,
+                nameof(PilotBoardRow.CorpNameDisplay) => row.CorpNameDisplay,
+                nameof(PilotBoardRow.KillCount) => row.KillCount,
+                nameof(PilotBoardRow.LossCount) => row.LossCount,
+                nameof(PilotBoardRow.AvgAttackersWhenAttacking) => row.AvgAttackersWhenAttacking,
+                nameof(PilotBoardRow.LastShipSeenName) => row.LastShipSeenName,
+                nameof(PilotBoardRow.LastShipSeenDateDisplay) => row.LastShipSeenAtUtc,
+                nameof(PilotBoardRow.LastShipSeenAtUtc) => row.LastShipSeenAtUtc,
+                nameof(PilotBoardRow.LastPublicCynoCapableHull) => row.LastPublicCynoCapableHull,
+                _ => GetBoardSortValueByReflection(row, sortMemberPath)
+            };
+        }
+
+        private static object? GetBoardSortValueByReflection(PilotBoardRow row, string sortMemberPath)
+        {
+            var property = typeof(PilotBoardRow).GetProperty(sortMemberPath);
+            return property?.GetValue(row);
+        }
+
+        private static void ApplySortIndicatorState(DataGrid pilotBoard, DataGridColumn activeColumn, ListSortDirection direction)
+        {
+            foreach (var column in pilotBoard.Columns)
+            {
+                column.SortDirection = ReferenceEquals(column, activeColumn)
+                    ? direction
+                    : null;
+            }
+        }
+
+        private static void ClearBoardSortIndicators(DataGrid pilotBoard)
+        {
+            foreach (var column in pilotBoard.Columns)
+            {
+                column.SortDirection = null;
+            }
+        }
+
+        private static string? GetSortMemberPathFromColumn(DataGridColumn column)
+        {
+            if (column is DataGridBoundColumn boundColumn &&
+                boundColumn.Binding is Binding binding &&
+                binding.Path != null)
+            {
+                return binding.Path.Path;
+            }
+
+            return null;
+        }
+    }
+}

--- a/PitmastersGrill/Services/DiagnosticsSupportSurface.cs
+++ b/PitmastersGrill/Services/DiagnosticsSupportSurface.cs
@@ -1,0 +1,92 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Views;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class DiagnosticsSupportSurface
+    {
+        private readonly DiagnosticsActionController _diagnosticsActionController;
+        private readonly DiagnosticsCacheMaintenanceController _diagnosticsCacheMaintenanceController;
+
+        private DiagnosticsSupportSurface(
+            DiagnosticsActionController diagnosticsActionController,
+            DiagnosticsCacheMaintenanceController diagnosticsCacheMaintenanceController)
+        {
+            _diagnosticsActionController = diagnosticsActionController ?? throw new ArgumentNullException(nameof(diagnosticsActionController));
+            _diagnosticsCacheMaintenanceController = diagnosticsCacheMaintenanceController ?? throw new ArgumentNullException(nameof(diagnosticsCacheMaintenanceController));
+        }
+
+        public static DiagnosticsSupportSurface Create(
+            Window owner,
+            DiagnosticsSupportView view,
+            BrowserLauncher browserLauncher,
+            ObservableCollection<ProviderHealthSnapshot> providerHealthRows,
+            Func<bool> isClipboardProcessing,
+            Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> showDialog,
+            Func<IReadOnlyList<ProviderHealthSnapshot>> getProviderHealthSnapshots,
+            Func<CacheStatsSnapshot> getCacheStats,
+            Func<int> clearExpiredCache,
+            Action vacuumCache,
+            Func<int> clearAllCache)
+        {
+            if (view == null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (providerHealthRows == null)
+            {
+                throw new ArgumentNullException(nameof(providerHealthRows));
+            }
+
+            var diagnosticsActionController = new DiagnosticsActionController(
+                owner,
+                view.DiagnosticsStatusTextBlock,
+                browserLauncher);
+            var providerHealthPresenter = new ProviderHealthPresenter();
+            var diagnosticsCacheStatsPresenter = new DiagnosticsCacheStatsPresenter();
+            var diagnosticsCacheMaintenanceController = new DiagnosticsCacheMaintenanceController(
+                isClipboardProcessing,
+                diagnosticsActionController.SetStatus,
+                showDialog,
+                getProviderHealthSnapshots,
+                snapshots => providerHealthPresenter.ApplySnapshots(providerHealthRows, snapshots),
+                getCacheStats,
+                clearExpiredCache,
+                vacuumCache,
+                clearAllCache,
+                diagnosticsCacheStatsPresenter,
+                view.SetCacheStatsText);
+
+            return new DiagnosticsSupportSurface(
+                diagnosticsActionController,
+                diagnosticsCacheMaintenanceController);
+        }
+
+        public void OpenLogs() => _diagnosticsActionController.OpenLogs();
+
+        public void PackageDiagnostics() => _diagnosticsActionController.PackageDiagnostics();
+
+        public void OpenDiagnosticsFolder() => _diagnosticsActionController.OpenDiagnosticsFolder();
+
+        public void SetStatus(string message) => _diagnosticsActionController.SetStatus(message);
+
+        public void RefreshProviderHealth() => _diagnosticsCacheMaintenanceController.RefreshProviderHealth();
+
+        public void RefreshProviderHealthUi() => _diagnosticsCacheMaintenanceController.RefreshProviderHealthUi();
+
+        public void RefreshCacheStats() => _diagnosticsCacheMaintenanceController.RefreshCacheStats();
+
+        public void RefreshCacheStatsUi() => _diagnosticsCacheMaintenanceController.RefreshCacheStatsUi();
+
+        public void ClearExpiredCache() => _diagnosticsCacheMaintenanceController.ClearExpiredCache();
+
+        public void VacuumCache() => _diagnosticsCacheMaintenanceController.VacuumCache();
+
+        public void ClearAllCache() => _diagnosticsCacheMaintenanceController.ClearAllCache();
+    }
+}

--- a/PitmastersGrill/Services/EveSessionContextSurface.cs
+++ b/PitmastersGrill/Services/EveSessionContextSurface.cs
@@ -1,0 +1,127 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class EveSessionContextSurface
+    {
+        private readonly Dispatcher _dispatcher;
+        private readonly EveSessionContextCoordinator _coordinator;
+        private readonly Func<CancellationToken, Task<EveSessionContext>> _captureAsync;
+        private readonly Func<bool> _isShuttingDown;
+        private readonly CancellationToken _shutdownToken;
+        private readonly TextBlock _characterText;
+        private readonly TextBlock _systemText;
+        private readonly TextBlock _evidenceSourceText;
+        private readonly TextBlock _observedAtText;
+        private readonly TextBlock _statusText;
+
+        private EveSessionContext? _currentContext;
+        private DateTime _lastRefreshUtc = DateTime.MinValue;
+        private bool _isRefreshInFlight;
+
+        public EveSessionContextSurface(
+            Dispatcher dispatcher,
+            EveSessionContextCoordinator coordinator,
+            Func<CancellationToken, Task<EveSessionContext>> captureAsync,
+            Func<bool> isShuttingDown,
+            CancellationToken shutdownToken,
+            TextBlock characterText,
+            TextBlock systemText,
+            TextBlock evidenceSourceText,
+            TextBlock observedAtText,
+            TextBlock statusText)
+        {
+            _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+            _coordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
+            _captureAsync = captureAsync ?? throw new ArgumentNullException(nameof(captureAsync));
+            _isShuttingDown = isShuttingDown ?? throw new ArgumentNullException(nameof(isShuttingDown));
+            _shutdownToken = shutdownToken;
+            _characterText = characterText ?? throw new ArgumentNullException(nameof(characterText));
+            _systemText = systemText ?? throw new ArgumentNullException(nameof(systemText));
+            _evidenceSourceText = evidenceSourceText ?? throw new ArgumentNullException(nameof(evidenceSourceText));
+            _observedAtText = observedAtText ?? throw new ArgumentNullException(nameof(observedAtText));
+            _statusText = statusText ?? throw new ArgumentNullException(nameof(statusText));
+        }
+
+        public void ApplyPendingContext()
+        {
+            ApplyContext(_coordinator.CreatePendingContext());
+        }
+
+        public bool IsStale(DateTime nowUtc)
+        {
+            return _coordinator.IsStale(_currentContext, _lastRefreshUtc, nowUtc);
+        }
+
+        public void TriggerRefresh(string reason, bool force)
+        {
+            if (!_coordinator.ShouldTriggerRefresh(
+                _isShuttingDown(),
+                force,
+                _currentContext,
+                _lastRefreshUtc,
+                _isRefreshInFlight,
+                DateTime.UtcNow))
+            {
+                return;
+            }
+
+            _ = RefreshAsync(reason);
+        }
+
+        private async Task RefreshAsync(string reason)
+        {
+            if (_isRefreshInFlight || _isShuttingDown())
+            {
+                return;
+            }
+
+            _isRefreshInFlight = true;
+            try
+            {
+                AppLogger.UiDebug($"EVE session context refresh started. reason='{reason}'");
+                var context = await _captureAsync(_shutdownToken);
+                _lastRefreshUtc = DateTime.UtcNow;
+                _currentContext = context;
+                await _dispatcher.InvokeAsync(() => ApplyProjection(_coordinator.BuildProjection(context)));
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown or refresh cancellation is expected.
+            }
+            catch (Exception ex)
+            {
+                AppLogger.UiWarn($"EVE session context refresh failed. reason='{reason}' message={ex.Message}");
+                var fallback = _coordinator.CreateFallbackContext();
+                _lastRefreshUtc = DateTime.UtcNow;
+                _currentContext = fallback;
+                await _dispatcher.InvokeAsync(() => ApplyProjection(_coordinator.BuildProjection(fallback)));
+            }
+            finally
+            {
+                _isRefreshInFlight = false;
+            }
+        }
+
+        private void ApplyContext(EveSessionContext context)
+        {
+            _currentContext = context;
+            ApplyProjection(_coordinator.BuildProjection(context));
+        }
+
+        private void ApplyProjection(EveSessionContextProjection projection)
+        {
+            _characterText.Text = projection.CharacterText;
+            _systemText.Text = projection.SystemText;
+            _evidenceSourceText.Text = projection.EvidenceSourceText;
+            _observedAtText.Text = projection.ObservedAtText;
+            _statusText.Text = projection.StatusText;
+        }
+    }
+}

--- a/PitmastersGrill/Services/IntelSupportSurface.cs
+++ b/PitmastersGrill/Services/IntelSupportSurface.cs
@@ -1,0 +1,207 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using PitmastersGrill.Views;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class IntelSupportSurface
+    {
+        private readonly Dispatcher _dispatcher;
+        private readonly Border _intelUpdateBanner;
+        private readonly TextBlock _intelUpdateStatusText;
+        private readonly TextBlock _intelUpdateDetailText;
+        private readonly IntelUpdateBannerController _intelUpdateBannerController;
+        private readonly IntelStatusDetailsPresenter _intelStatusDetailsPresenter;
+        private readonly IntelActionsController _intelActionsController;
+        private readonly IntelMaintenanceActionsController _intelMaintenanceActionsController;
+
+        private IntelSupportSurface(
+            Dispatcher dispatcher,
+            Border intelUpdateBanner,
+            TextBlock intelUpdateStatusText,
+            TextBlock intelUpdateDetailText,
+            IntelUpdateBannerController intelUpdateBannerController,
+            IntelStatusDetailsPresenter intelStatusDetailsPresenter,
+            IntelActionsController intelActionsController,
+            IntelMaintenanceActionsController intelMaintenanceActionsController)
+        {
+            _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+            _intelUpdateBanner = intelUpdateBanner ?? throw new ArgumentNullException(nameof(intelUpdateBanner));
+            _intelUpdateStatusText = intelUpdateStatusText ?? throw new ArgumentNullException(nameof(intelUpdateStatusText));
+            _intelUpdateDetailText = intelUpdateDetailText ?? throw new ArgumentNullException(nameof(intelUpdateDetailText));
+            _intelUpdateBannerController = intelUpdateBannerController ?? throw new ArgumentNullException(nameof(intelUpdateBannerController));
+            _intelStatusDetailsPresenter = intelStatusDetailsPresenter ?? throw new ArgumentNullException(nameof(intelStatusDetailsPresenter));
+            _intelActionsController = intelActionsController ?? throw new ArgumentNullException(nameof(intelActionsController));
+            _intelMaintenanceActionsController = intelMaintenanceActionsController ?? throw new ArgumentNullException(nameof(intelMaintenanceActionsController));
+        }
+
+        public static IntelSupportSurface Create(
+            Window owner,
+            Dispatcher dispatcher,
+            IntelSupportView view,
+            BackgroundIntelUpdateService backgroundIntelUpdateService,
+            SettingsTabController settingsTabController,
+            Func<AppSettings> getAppSettings,
+            Action saveSettings,
+            Func<bool> isApplyingSettings,
+            Func<bool> isShuttingDown,
+            CancellationToken shutdownToken,
+            Func<IReadOnlyList<PilotBoardRow>> getCurrentRows,
+            Func<string, Task> refreshCurrentBoardRowsFromLocalIntelAsync,
+            Func<bool> isClipboardProcessing,
+            Action<string> setDiagnosticsStatus,
+            Action<bool> setRebuildKillmailDerivedIntelEnabled,
+            Func<int> getSeedDays,
+            Func<CancellationToken, Task<KillmailDerivedIntelRebuildResult>> rebuildDerivedIntelAsync,
+            Func<int, CancellationToken, Task> enableKillmailDbPullAsync,
+            Action refreshCacheStatsUi,
+            Action refreshConfirmedCynoModuleStateForCurrentRows,
+            Func<string, string, MessageBoxButton, MessageBoxImage, MessageBoxResult> showDialog)
+        {
+            if (view == null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            var intelUpdateBannerController = new IntelUpdateBannerController(dispatcher);
+            var intelStatusDetailsPresenter = new IntelStatusDetailsPresenter(
+                view.IntelLastUpdatedTextBlock,
+                view.IntelOldestKillmailDayTextBlock,
+                view.IntelNewestKillmailDayTextBlock,
+                view.IntelCurrentUpdateStatusTextBlock,
+                view.IntelTotalProgressBarControl,
+                view.IntelTotalProgressTextBlock,
+                view.IntelCurrentDayProgressBarControl,
+                view.IntelCurrentDayProgressTextBlock,
+                view.IntelLiveFeedSourceTextBlock,
+                view.IntelLiveFeedStatusTextBlock,
+                view.IntelLiveFeedEnabledTextBlock,
+                view.IntelLiveFeedRecentImportsTextBlock,
+                view.IntelLiveFeedNextSequenceTextBlock,
+                view.IntelLiveFeedLastProcessedSequenceTextBlock,
+                view.IntelLiveFeedLastSuccessTextBlock,
+                view.IntelLiveFeedLastCaughtUpTextBlock,
+                view.IntelLiveFeedLastErrorTextBlock,
+                view.TodaysFreshnessStatusTextBlock,
+                view.TodaysFreshnessVisiblePilotsTextBlock,
+                view.TodaysFreshnessEntitiesQueriedTextBlock,
+                view.TodaysFreshnessResultsFoundTextBlock,
+                view.TodaysFreshnessKnownSkippedTextBlock,
+                view.TodaysFreshnessImportedTextBlock,
+                view.TodaysFreshnessFailedTextBlock,
+                view.TodaysFreshnessLastRunTextBlock,
+                view.TodaysFreshnessDetailTextBlock,
+                view.TodaysFreshnessLastErrorTextBlock,
+                view.RunTodaysFreshnessButtonControl,
+                view.HistoricalFreshnessStatusTextBlock,
+                view.HistoricalFreshnessModeTextBlock,
+                view.HistoricalFreshnessVisiblePilotsTextBlock,
+                view.HistoricalFreshnessCandidatesConsideredTextBlock,
+                view.HistoricalFreshnessCandidatesSkippedCooldownTextBlock,
+                view.HistoricalFreshnessPilotsCheckedTextBlock,
+                view.HistoricalFreshnessDaysCheckedTextBlock,
+                view.HistoricalFreshnessEntitiesQueriedTextBlock,
+                view.HistoricalFreshnessResultsFoundTextBlock,
+                view.HistoricalFreshnessKnownSkippedTextBlock,
+                view.HistoricalFreshnessImportedTextBlock,
+                view.HistoricalFreshnessFailedTextBlock,
+                view.HistoricalFreshnessLastRunTextBlock,
+                view.HistoricalFreshnessDetailTextBlock,
+                view.HistoricalFreshnessLastErrorTextBlock,
+                view.RunHistoricalFreshnessButtonControl);
+            var intelActionsController = new IntelActionsController(
+                owner,
+                backgroundIntelUpdateService,
+                settingsTabController,
+                getAppSettings,
+                saveSettings,
+                isApplyingSettings,
+                isShuttingDown,
+                shutdownToken,
+                getCurrentRows,
+                refreshCurrentBoardRowsFromLocalIntelAsync);
+            var intelMaintenanceActionsController = new IntelMaintenanceActionsController(
+                isClipboardProcessing,
+                setDiagnosticsStatus,
+                setRebuildKillmailDerivedIntelEnabled,
+                enabled => view.EnableKillmailDbPullButtonControl.IsEnabled = enabled,
+                getSeedDays,
+                isShuttingDown,
+                shutdownToken,
+                rebuildDerivedIntelAsync,
+                enableKillmailDbPullAsync,
+                refreshCacheStatsUi,
+                refreshConfirmedCynoModuleStateForCurrentRows,
+                showDialog);
+
+            return new IntelSupportSurface(
+                dispatcher,
+                view.IntelUpdateBannerControl,
+                view.IntelUpdateStatusTextBlock,
+                view.IntelUpdateDetailTextBlock,
+                intelUpdateBannerController,
+                intelStatusDetailsPresenter,
+                intelActionsController,
+                intelMaintenanceActionsController);
+        }
+
+        public void HandleStatusChanged(IntelUpdateStatusSnapshot snapshot, bool isShuttingDown)
+        {
+            _intelUpdateBannerController.HandleStatusChanged(
+                snapshot,
+                _intelUpdateBanner,
+                _intelUpdateStatusText,
+                _intelUpdateDetailText);
+
+            if (_dispatcher.CheckAccess())
+            {
+                ApplyStatusDetails(snapshot, isShuttingDown);
+            }
+            else
+            {
+                _dispatcher.Invoke(() => ApplyStatusDetails(snapshot, isShuttingDown));
+            }
+        }
+
+        public void ApplySnapshot(IntelUpdateStatusSnapshot snapshot, bool isShuttingDown)
+        {
+            _intelUpdateBannerController.ApplySnapshot(
+                snapshot,
+                _intelUpdateBanner,
+                _intelUpdateStatusText,
+                _intelUpdateDetailText);
+            ApplyStatusDetails(snapshot, isShuttingDown);
+        }
+
+        public Task RunEnableKillmailDbPullAsync() => _intelMaintenanceActionsController.RunEnableKillmailDbPullAsync();
+
+        public Task HandleLiveFeedToggleAsync(bool enabled) => _intelActionsController.HandleLiveFeedToggleAsync(enabled);
+
+        public Task RunRebuildKillmailDerivedIntelAsync() => _intelMaintenanceActionsController.RunRebuildKillmailDerivedIntelAsync();
+
+        public Task RunTodaysFreshnessAsync() => _intelActionsController.RunTodaysFreshnessAsync();
+
+        public Task RunHistoricalFreshnessAsync() => _intelActionsController.RunHistoricalFreshnessAsync();
+
+        public List<long> GetVisibleCharacterIdsForBackgroundHistoricalRepair()
+            => _intelActionsController.GetVisibleCharacterIdsForBackgroundHistoricalRepair();
+
+        private void ApplyStatusDetails(IntelUpdateStatusSnapshot snapshot, bool isShuttingDown)
+        {
+            if (snapshot == null)
+            {
+                return;
+            }
+
+            var projection = IntelStatusDetailsProjection.Create(snapshot, isShuttingDown);
+            _intelStatusDetailsPresenter.Apply(projection);
+        }
+    }
+}

--- a/PitmastersGrill/Services/MainWindowNativeInputController.cs
+++ b/PitmastersGrill/Services/MainWindowNativeInputController.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Windows.Input;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class MainWindowNativeInputController
+    {
+        private bool _globalResetWindowHotKeyRegistered;
+        private bool _globalClearBoardHotKeyRegistered;
+        private bool _globalToggleBoardModeHotKeyRegistered;
+
+        public void Attach(
+            IntPtr hwnd,
+            Func<IntPtr, bool> addClipboardFormatListener,
+            Func<IntPtr, int, uint, uint, bool> registerHotKey,
+            uint modControl,
+            int globalResetWindowHotKeyId,
+            int globalClearBoardHotKeyId,
+            int globalToggleBoardModeHotKeyId,
+            Action<string> logInfo,
+            Action<string> logWarn,
+            Func<int> getLastWin32Error)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            addClipboardFormatListener(hwnd);
+
+            _globalClearBoardHotKeyRegistered = registerHotKey(
+                hwnd,
+                globalClearBoardHotKeyId,
+                0,
+                (uint)KeyInterop.VirtualKeyFromKey(Key.Delete));
+
+            if (_globalClearBoardHotKeyRegistered)
+            {
+                logInfo("Global Delete clear-board hotkey registered.");
+            }
+            else
+            {
+                logWarn($"Global Delete clear-board hotkey registration failed. error={getLastWin32Error()}");
+            }
+
+            _globalToggleBoardModeHotKeyRegistered = registerHotKey(
+                hwnd,
+                globalToggleBoardModeHotKeyId,
+                0,
+                (uint)KeyInterop.VirtualKeyFromKey(Key.Insert));
+
+            if (_globalToggleBoardModeHotKeyRegistered)
+            {
+                logInfo("Global Insert board-mode hotkey registered.");
+            }
+            else
+            {
+                logWarn($"Global Insert board-mode hotkey registration failed. error={getLastWin32Error()}");
+            }
+
+            _globalResetWindowHotKeyRegistered = registerHotKey(
+                hwnd,
+                globalResetWindowHotKeyId,
+                modControl,
+                (uint)KeyInterop.VirtualKeyFromKey(Key.Home));
+
+            if (_globalResetWindowHotKeyRegistered)
+            {
+                logInfo("Global Ctrl+Home reset-window hotkey registered.");
+            }
+            else
+            {
+                logWarn($"Global Ctrl+Home hotkey registration failed. win32Error={getLastWin32Error()}");
+            }
+        }
+
+        public void Detach(
+            IntPtr hwnd,
+            Func<IntPtr, bool> removeClipboardFormatListener,
+            Func<IntPtr, int, bool> unregisterHotKey,
+            int globalResetWindowHotKeyId,
+            int globalClearBoardHotKeyId,
+            int globalToggleBoardModeHotKeyId,
+            Action<string> logInfo,
+            Action<string> logWarn,
+            Func<int> getLastWin32Error)
+        {
+            if (hwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (_globalClearBoardHotKeyRegistered)
+            {
+                if (unregisterHotKey(hwnd, globalClearBoardHotKeyId))
+                {
+                    logInfo("Global Delete clear-board hotkey unregistered.");
+                }
+                else
+                {
+                    logWarn($"Global Delete clear-board hotkey unregister failed. error={getLastWin32Error()}");
+                }
+
+                _globalClearBoardHotKeyRegistered = false;
+            }
+
+            if (_globalToggleBoardModeHotKeyRegistered)
+            {
+                if (unregisterHotKey(hwnd, globalToggleBoardModeHotKeyId))
+                {
+                    logInfo("Global Insert board-mode hotkey unregistered.");
+                }
+                else
+                {
+                    logWarn($"Global Insert board-mode hotkey unregister failed. error={getLastWin32Error()}");
+                }
+
+                _globalToggleBoardModeHotKeyRegistered = false;
+            }
+
+            if (_globalResetWindowHotKeyRegistered)
+            {
+                if (!unregisterHotKey(hwnd, globalResetWindowHotKeyId))
+                {
+                    logWarn($"Global Ctrl+Home hotkey unregistration failed. win32Error={getLastWin32Error()}");
+                }
+
+                _globalResetWindowHotKeyRegistered = false;
+            }
+
+            removeClipboardFormatListener(hwnd);
+        }
+    }
+}

--- a/PitmastersGrill/Services/PilotDetailSurface.cs
+++ b/PitmastersGrill/Services/PilotDetailSurface.cs
@@ -1,0 +1,374 @@
+using PitmastersGrill.Models;
+using PitmastersGrill.Persistence;
+using PitmastersGrill.Views;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using FormsScreen = System.Windows.Forms.Screen;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class PilotDetailSurface
+    {
+        private readonly Window _owner;
+        private readonly Border _detailPane;
+        private readonly TextBlock _selectedCharacterText;
+        private readonly TextBlock _fullCorpText;
+        private readonly TextBlock _fullAllianceText;
+        private readonly TextBlock _freshnessText;
+        private readonly TextBlock _recentPublicActivityText;
+        private readonly TextBlock _cynoSignalText;
+        private readonly ProgressBar _cynoConfidenceBar;
+        private readonly TextBlock _cynoEvidenceText;
+        private readonly TextBlock _cynoLimitationsText;
+        private readonly TextBlock _explainabilityText;
+        private readonly TextBox _notesTagsBox;
+        private readonly CheckBox _knownCynoOverrideCheckBox;
+        private readonly CheckBox _baitOverrideCheckBox;
+        private readonly Button _ignoreAllianceButton;
+        private readonly Button _watchPilotDetailAction;
+        private readonly DetailPaneController _detailPaneController;
+        private readonly PilotDetailWindowLifecycleController _pilotDetailWindowLifecycleController;
+        private readonly PilotDetailWindowPlacementController _pilotDetailWindowPlacementController;
+        private readonly PilotBoardRowDetailFormatter _pilotBoardRowDetailFormatter;
+        private readonly PilotDetailActionsPresenter _pilotDetailActionsPresenter;
+        private readonly WatchedPilotRepository _watchedPilotRepository;
+        private readonly NotesRepository _notesRepository;
+        private readonly SettingsTabController _settingsTabController;
+        private readonly Func<AppSettings> _getAppSettings;
+        private readonly Func<long, bool> _allianceIsIgnored;
+        private readonly Func<PilotBoardRow?, IReadOnlyCollection<PilotBoardRow>, PilotBoardRow?> _getSelectedOrDisplayedRow;
+        private readonly Func<PilotBoardRow, IgnoreEntryType, bool> _tryIgnoreForRow;
+        private readonly Action<PilotBoardRow> _openZkillForRow;
+        private readonly Action _applyCurrentBoardOrdering;
+        private readonly Action<PilotBoardRow> _onWatchedRowChanged;
+        private readonly double _detailWindowGap;
+
+        private PilotDetailWindow? _activePilotDetailWindow;
+
+        public PilotDetailSurface(
+            Window owner,
+            Border detailPane,
+            TextBlock selectedCharacterText,
+            TextBlock fullCorpText,
+            TextBlock fullAllianceText,
+            TextBlock freshnessText,
+            TextBlock recentPublicActivityText,
+            TextBlock cynoSignalText,
+            ProgressBar cynoConfidenceBar,
+            TextBlock cynoEvidenceText,
+            TextBlock cynoLimitationsText,
+            TextBlock explainabilityText,
+            TextBox notesTagsBox,
+            CheckBox knownCynoOverrideCheckBox,
+            CheckBox baitOverrideCheckBox,
+            Button ignoreAllianceButton,
+            Button watchPilotDetailAction,
+            DetailPaneController detailPaneController,
+            PilotDetailWindowLifecycleController pilotDetailWindowLifecycleController,
+            PilotDetailWindowPlacementController pilotDetailWindowPlacementController,
+            PilotBoardRowDetailFormatter pilotBoardRowDetailFormatter,
+            PilotDetailActionsPresenter pilotDetailActionsPresenter,
+            WatchedPilotRepository watchedPilotRepository,
+            NotesRepository notesRepository,
+            SettingsTabController settingsTabController,
+            Func<AppSettings> getAppSettings,
+            Func<long, bool> allianceIsIgnored,
+            Func<PilotBoardRow?, IReadOnlyCollection<PilotBoardRow>, PilotBoardRow?> getSelectedOrDisplayedRow,
+            Func<PilotBoardRow, IgnoreEntryType, bool> tryIgnoreForRow,
+            Action<PilotBoardRow> openZkillForRow,
+            Action applyCurrentBoardOrdering,
+            Action<PilotBoardRow> onWatchedRowChanged,
+            double detailWindowGap)
+        {
+            _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+            _detailPane = detailPane ?? throw new ArgumentNullException(nameof(detailPane));
+            _selectedCharacterText = selectedCharacterText ?? throw new ArgumentNullException(nameof(selectedCharacterText));
+            _fullCorpText = fullCorpText ?? throw new ArgumentNullException(nameof(fullCorpText));
+            _fullAllianceText = fullAllianceText ?? throw new ArgumentNullException(nameof(fullAllianceText));
+            _freshnessText = freshnessText ?? throw new ArgumentNullException(nameof(freshnessText));
+            _recentPublicActivityText = recentPublicActivityText ?? throw new ArgumentNullException(nameof(recentPublicActivityText));
+            _cynoSignalText = cynoSignalText ?? throw new ArgumentNullException(nameof(cynoSignalText));
+            _cynoConfidenceBar = cynoConfidenceBar ?? throw new ArgumentNullException(nameof(cynoConfidenceBar));
+            _cynoEvidenceText = cynoEvidenceText ?? throw new ArgumentNullException(nameof(cynoEvidenceText));
+            _cynoLimitationsText = cynoLimitationsText ?? throw new ArgumentNullException(nameof(cynoLimitationsText));
+            _explainabilityText = explainabilityText ?? throw new ArgumentNullException(nameof(explainabilityText));
+            _notesTagsBox = notesTagsBox ?? throw new ArgumentNullException(nameof(notesTagsBox));
+            _knownCynoOverrideCheckBox = knownCynoOverrideCheckBox ?? throw new ArgumentNullException(nameof(knownCynoOverrideCheckBox));
+            _baitOverrideCheckBox = baitOverrideCheckBox ?? throw new ArgumentNullException(nameof(baitOverrideCheckBox));
+            _ignoreAllianceButton = ignoreAllianceButton ?? throw new ArgumentNullException(nameof(ignoreAllianceButton));
+            _watchPilotDetailAction = watchPilotDetailAction ?? throw new ArgumentNullException(nameof(watchPilotDetailAction));
+            _detailPaneController = detailPaneController ?? throw new ArgumentNullException(nameof(detailPaneController));
+            _pilotDetailWindowLifecycleController = pilotDetailWindowLifecycleController ?? throw new ArgumentNullException(nameof(pilotDetailWindowLifecycleController));
+            _pilotDetailWindowPlacementController = pilotDetailWindowPlacementController ?? throw new ArgumentNullException(nameof(pilotDetailWindowPlacementController));
+            _pilotBoardRowDetailFormatter = pilotBoardRowDetailFormatter ?? throw new ArgumentNullException(nameof(pilotBoardRowDetailFormatter));
+            _pilotDetailActionsPresenter = pilotDetailActionsPresenter ?? throw new ArgumentNullException(nameof(pilotDetailActionsPresenter));
+            _watchedPilotRepository = watchedPilotRepository ?? throw new ArgumentNullException(nameof(watchedPilotRepository));
+            _notesRepository = notesRepository ?? throw new ArgumentNullException(nameof(notesRepository));
+            _settingsTabController = settingsTabController ?? throw new ArgumentNullException(nameof(settingsTabController));
+            _getAppSettings = getAppSettings ?? throw new ArgumentNullException(nameof(getAppSettings));
+            _allianceIsIgnored = allianceIsIgnored ?? throw new ArgumentNullException(nameof(allianceIsIgnored));
+            _getSelectedOrDisplayedRow = getSelectedOrDisplayedRow ?? throw new ArgumentNullException(nameof(getSelectedOrDisplayedRow));
+            _tryIgnoreForRow = tryIgnoreForRow ?? throw new ArgumentNullException(nameof(tryIgnoreForRow));
+            _openZkillForRow = openZkillForRow ?? throw new ArgumentNullException(nameof(openZkillForRow));
+            _applyCurrentBoardOrdering = applyCurrentBoardOrdering ?? throw new ArgumentNullException(nameof(applyCurrentBoardOrdering));
+            _onWatchedRowChanged = onWatchedRowChanged ?? throw new ArgumentNullException(nameof(onWatchedRowChanged));
+            _detailWindowGap = detailWindowGap;
+        }
+
+        public void ApplyThemeToActiveWindow(ResourceDictionary resources)
+        {
+            _activePilotDetailWindow?.ApplyThemeResources(resources);
+        }
+
+        public void OpenDetailsWindow(PilotBoardRow row)
+        {
+            var action = _pilotDetailWindowLifecycleController.DecideOpenAction(row.CharacterName);
+            if (action == PilotDetailWindowOpenAction.ActivateExisting)
+            {
+                _activePilotDetailWindow?.Activate();
+                return;
+            }
+
+            if (action == PilotDetailWindowOpenAction.ReplaceExisting)
+            {
+                CloseActiveDetailWindow();
+            }
+
+            _activePilotDetailWindow = new PilotDetailWindow(
+                row,
+                _pilotBoardRowDetailFormatter,
+                _notesRepository,
+                TryIgnoreForRow,
+                ToggleWatchForRow,
+                _openZkillForRow)
+            {
+                Owner = _owner
+            };
+
+            _activePilotDetailWindow.ApplyThemeResources(_owner.Resources);
+            _activePilotDetailWindow.Topmost = _owner.Topmost;
+            PositionDetailWindow(_activePilotDetailWindow);
+            _activePilotDetailWindow.Closed += ActivePilotDetailWindow_Closed;
+            _pilotDetailWindowLifecycleController.MarkWindowOpened(row.CharacterName);
+            _activePilotDetailWindow.Show();
+            AppLogger.UiInfo($"Details window opened. character='{row.CharacterName}'");
+        }
+
+        public void CloseActiveDetailWindow()
+        {
+            if (_activePilotDetailWindow == null)
+            {
+                return;
+            }
+
+            var window = _activePilotDetailWindow;
+            _activePilotDetailWindow = null;
+            window.Closed -= ActivePilotDetailWindow_Closed;
+            window.SaveCurrentState();
+            _pilotDetailWindowLifecycleController.ClearActiveWindow();
+            window.Close();
+        }
+
+        public void ShowDetailPane(PilotBoardRow row)
+        {
+            _detailPaneController.ShowDetailPane(
+                row,
+                _detailPane,
+                _selectedCharacterText,
+                _fullCorpText,
+                _fullAllianceText,
+                _freshnessText,
+                _recentPublicActivityText,
+                _cynoSignalText,
+                _cynoConfidenceBar,
+                _cynoEvidenceText,
+                _cynoLimitationsText,
+                _explainabilityText,
+                _notesTagsBox,
+                _knownCynoOverrideCheckBox,
+                _baitOverrideCheckBox);
+
+            UpdateIgnoreAllianceButtonState(row);
+            UpdateWatchPilotDetailActionState(row);
+        }
+
+        public void HideDetailPane()
+        {
+            _detailPaneController.HideDetailPane(
+                _detailPane,
+                _notesTagsBox,
+                _knownCynoOverrideCheckBox,
+                _baitOverrideCheckBox);
+
+            _explainabilityText.Text = "Explainability: --";
+            _recentPublicActivityText.Text = "Recent Public Kill/Loss Activity: --";
+            _cynoSignalText.Text = "Cyno Signal: Unknown";
+            _cynoConfidenceBar.Value = 0;
+            _cynoEvidenceText.Text = "Evidence: --";
+            _cynoLimitationsText.Text = "Limitations: --";
+
+            UpdateIgnoreAllianceButtonState(null);
+            UpdateWatchPilotDetailActionState(null);
+        }
+
+        public void SaveCurrentNotesAndTags(PilotBoardRow? selectedRow)
+        {
+            if (_activePilotDetailWindow != null)
+            {
+                _activePilotDetailWindow.SaveCurrentState();
+                return;
+            }
+
+            _detailPaneController.SaveCurrentNotesAndTags(
+                _notesTagsBox.Text,
+                _knownCynoOverrideCheckBox.IsChecked == true,
+                _baitOverrideCheckBox.IsChecked == true,
+                selectedRow);
+        }
+
+        public PilotBoardRow? GetSelectedOrDisplayedDetailRow(PilotBoardRow? selectedRow, IReadOnlyCollection<PilotBoardRow> currentRows)
+        {
+            return _getSelectedOrDisplayedRow(selectedRow, currentRows);
+        }
+
+        public void RefreshActiveDetailWindowIfSelected(PilotBoardRow row)
+        {
+            if (_activePilotDetailWindow != null &&
+                _pilotDetailWindowLifecycleController.ShouldRefreshActiveWindow(row.CharacterName))
+            {
+                _activePilotDetailWindow.RefreshRow();
+            }
+        }
+
+        public void UpdateIgnoreAllianceButtonState(PilotBoardRow? row)
+        {
+            var allianceId = _pilotDetailActionsPresenter.TryGetAllianceId(row?.AllianceId);
+            var state = _pilotDetailActionsPresenter.BuildIgnoreAllianceActionState(
+                row,
+                allianceId.HasValue && _allianceIsIgnored(allianceId.Value));
+
+            _ignoreAllianceButton.IsEnabled = state.IsEnabled;
+            _ignoreAllianceButton.ToolTip = state.ToolTip;
+        }
+
+        public void UpdateWatchPilotDetailActionState(PilotBoardRow? row)
+        {
+            var state = _pilotDetailActionsPresenter.BuildWatchPilotActionState(row);
+            _watchPilotDetailAction.IsEnabled = state.IsEnabled;
+            _watchPilotDetailAction.Content = state.Content;
+            _watchPilotDetailAction.ToolTip = state.ToolTip;
+            _watchPilotDetailAction.SetResourceReference(
+                Control.ForegroundProperty,
+                state.ForegroundResourceKey);
+        }
+
+        public void ToggleWatchForRow(PilotBoardRow row)
+        {
+            var pilotId = _pilotDetailActionsPresenter.TryGetPilotId(row.CharacterId);
+            if (!pilotId.HasValue)
+            {
+                UpdateWatchPilotDetailActionState(row);
+                AppLogger.UiWarn($"Watch requested without a valid pilot ID. character='{row.CharacterName}'");
+                return;
+            }
+
+            var newWatchedState = !row.IsWatched;
+            if (!_watchedPilotRepository.SetWatched(row.CharacterId, newWatchedState))
+            {
+                UpdateWatchPilotDetailActionState(row);
+                AppLogger.UiWarn($"Watch state change failed. character='{row.CharacterName}' characterId='{row.CharacterId}'");
+                return;
+            }
+
+            row.IsWatched = newWatchedState;
+            _applyCurrentBoardOrdering();
+            UpdateWatchPilotDetailActionState(row);
+            _onWatchedRowChanged(row);
+
+            AppLogger.UiInfo(
+                $"Watch state changed. character='{row.CharacterName}' characterId='{row.CharacterId}' watched={row.IsWatched}");
+        }
+
+        public bool TryIgnoreAllianceForSelectedOrDisplayedRow(PilotBoardRow? selectedRow, IReadOnlyCollection<PilotBoardRow> currentRows)
+        {
+            var row = GetSelectedOrDisplayedDetailRow(selectedRow, currentRows);
+            if (row == null)
+            {
+                AppLogger.UiWarn("Ignore alliance requested with no selected or displayed detail row.");
+                return false;
+            }
+
+            return TryIgnoreForRow(row, IgnoreEntryType.Alliance);
+        }
+
+        private bool TryIgnoreForRow(PilotBoardRow selectedRow, IgnoreEntryType type)
+        {
+            return _tryIgnoreForRow(selectedRow, type);
+        }
+
+        private void PositionDetailWindow(PilotDetailWindow detailWindow)
+        {
+            detailWindow.WindowStartupLocation = WindowStartupLocation.Manual;
+
+            var detailWidth = detailWindow.Width > 0 ? detailWindow.Width : 430;
+            var detailHeight = detailWindow.Height > 0 ? detailWindow.Height : 360;
+            var ownerWidth = _owner.ActualWidth > 0 ? _owner.ActualWidth : _owner.Width;
+            var ownerHeight = _owner.ActualHeight > 0 ? _owner.ActualHeight : _owner.Height;
+            var ownerLeft = double.IsNaN(_owner.Left) ? 0 : _owner.Left;
+            var ownerTop = double.IsNaN(_owner.Top) ? 0 : _owner.Top;
+            var ownerHandle = new WindowInteropHelper(_owner).Handle;
+            var monitor = ownerHandle != IntPtr.Zero
+                ? FormsScreen.FromHandle(ownerHandle)
+                : FormsScreen.FromPoint(new System.Drawing.Point(
+                    (int)Math.Round(ownerLeft),
+                    (int)Math.Round(ownerTop)));
+
+            var presentationSource = PresentationSource.FromVisual(_owner);
+            var transformFromDevice = presentationSource?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
+            var workAreaPixels = monitor.WorkingArea;
+            var workTopLeft = transformFromDevice.Transform(new Point(workAreaPixels.Left, workAreaPixels.Top));
+            var workBottomRight = transformFromDevice.Transform(new Point(workAreaPixels.Right, workAreaPixels.Bottom));
+            var workLeft = workTopLeft.X;
+            var workTop = workTopLeft.Y;
+            var workRight = workBottomRight.X;
+            var workBottom = workBottomRight.Y;
+            var preferLeft = _settingsTabController.GetPilotDetailPlacementPreference(_getAppSettings()) == PilotDetailPlacementPreference.AutoPreferLeft;
+            var placement = _pilotDetailWindowPlacementController.BuildPlacement(
+                detailWidth,
+                detailHeight,
+                ownerLeft,
+                ownerTop,
+                ownerWidth,
+                workLeft,
+                workTop,
+                workRight,
+                workBottom,
+                preferLeft,
+                _detailWindowGap);
+
+            detailWindow.Left = placement.Left;
+            detailWindow.Top = placement.Top;
+
+            if (placement.WasAdjusted)
+            {
+                AppLogger.UiInfo(
+                    $"Detail window placement adjusted. ownerBounds=({ownerLeft:0.##},{ownerTop:0.##},{ownerWidth:0.##},{ownerHeight:0.##}) workArea=({workLeft:0.##},{workTop:0.##},{workRight - workLeft:0.##},{workBottom - workTop:0.##}) preferredSide={placement.PreferredSide} finalSide={placement.FinalSide} finalBounds=({placement.Left:0.##},{placement.Top:0.##},{detailWidth:0.##},{detailHeight:0.##})");
+            }
+        }
+
+        private void ActivePilotDetailWindow_Closed(object? sender, EventArgs e)
+        {
+            if (_activePilotDetailWindow != null)
+            {
+                _activePilotDetailWindow.Closed -= ActivePilotDetailWindow_Closed;
+                _activePilotDetailWindow = null;
+            }
+
+            _pilotDetailWindowLifecycleController.ClearActiveWindow();
+        }
+    }
+}

--- a/PitmastersGrill/Services/WindowLayoutSurface.cs
+++ b/PitmastersGrill/Services/WindowLayoutSurface.cs
@@ -1,0 +1,193 @@
+using PitmastersGrill.Models;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace PitmastersGrill.Services
+{
+    public sealed class WindowLayoutSurface
+    {
+        private readonly WindowLayoutController _windowLayoutController;
+        private readonly Action<AppSettings> _saveSettings;
+        private readonly Func<IReadOnlyList<Rect>> _getMonitorWorkAreasDip;
+
+        public WindowLayoutSurface(
+            WindowLayoutController windowLayoutController,
+            Action<AppSettings> saveSettings,
+            Func<IReadOnlyList<Rect>> getMonitorWorkAreasDip)
+        {
+            _windowLayoutController = windowLayoutController ?? throw new ArgumentNullException(nameof(windowLayoutController));
+            _saveSettings = saveSettings ?? throw new ArgumentNullException(nameof(saveSettings));
+            _getMonitorWorkAreasDip = getMonitorWorkAreasDip ?? throw new ArgumentNullException(nameof(getMonitorWorkAreasDip));
+        }
+
+        public bool IsRestoringWindowLayout { get; private set; }
+
+        public WindowState LastNonMinimizedWindowState { get; private set; } = WindowState.Normal;
+
+        public Rect LastKnownNormalBounds { get; private set; } = Rect.Empty;
+
+        public void HandleWindowStateChanged(WindowState windowState, Rect restoreBounds, Rect currentBounds)
+        {
+            if (windowState != WindowState.Minimized)
+            {
+                LastNonMinimizedWindowState = windowState;
+            }
+
+            if (windowState == WindowState.Maximized && _windowLayoutController.IsUsableWindowBounds(restoreBounds))
+            {
+                LastKnownNormalBounds = restoreBounds;
+            }
+            else
+            {
+                TrackCurrentNormalWindowBounds(windowState, currentBounds);
+            }
+        }
+
+        public void TrackCurrentNormalWindowBounds(WindowState windowState, Rect currentBounds)
+        {
+            if (windowState != WindowState.Normal)
+            {
+                return;
+            }
+
+            if (!_windowLayoutController.IsUsableWindowBounds(currentBounds))
+            {
+                return;
+            }
+
+            LastKnownNormalBounds = currentBounds;
+        }
+
+        public void RestoreFromSettings(
+            AppSettings settings,
+            WindowLayoutMode mode,
+            double minWidth,
+            double minHeight,
+            double minimumSavedWindowWidth,
+            double minimumSavedWindowHeight,
+            double minimumVisibleWindowEdge,
+            double defaultWindowWidth,
+            double defaultWindowHeight,
+            Action<Rect> applyTargetBounds,
+            Action<WindowState> applyWindowState,
+            Action<string> logInfo)
+        {
+            var workAreas = _getMonitorWorkAreasDip();
+            var virtualDesktopSummary = _windowLayoutController.BuildVirtualDesktopSummary(workAreas);
+            var restoreResult = _windowLayoutController.BuildRestoreResult(
+                settings,
+                mode,
+                minWidth,
+                minHeight,
+                minimumSavedWindowWidth,
+                minimumSavedWindowHeight,
+                minimumVisibleWindowEdge,
+                defaultWindowWidth,
+                defaultWindowHeight,
+                workAreas);
+
+            logInfo(
+                $"Window layout restore decision={restoreResult.RestoreDecision} mode={mode} savedBounds={_windowLayoutController.DescribeRect(restoreResult.SavedBounds)} fallbackReason='{restoreResult.RestoreReason}' wasMaximized={restoreResult.ShouldRestoreMaximized} virtualWorkAreas={virtualDesktopSummary}");
+
+            IsRestoringWindowLayout = true;
+            try
+            {
+                applyWindowState(WindowState.Normal);
+                applyTargetBounds(restoreResult.TargetBounds);
+                LastKnownNormalBounds = restoreResult.TargetBounds;
+
+                if (restoreResult.ShouldRestoreMaximized)
+                {
+                    applyWindowState(WindowState.Maximized);
+                }
+
+                LastNonMinimizedWindowState = restoreResult.LastNonMinimizedWindowState;
+            }
+            finally
+            {
+                IsRestoringWindowLayout = false;
+            }
+
+            logInfo(
+                $"Window layout restore applied mode={mode} finalBounds={_windowLayoutController.DescribeRect(restoreResult.TargetBounds)} finalWindowState={(restoreResult.ShouldRestoreMaximized ? WindowState.Maximized : WindowState.Normal)}");
+        }
+
+        public void SaveToSettings(
+            AppSettings settings,
+            string reason,
+            WindowLayoutMode mode,
+            WindowState windowState,
+            Rect restoreBounds,
+            Rect currentBounds,
+            double minWidth,
+            double minHeight,
+            double minimumSavedWindowWidth,
+            double minimumSavedWindowHeight,
+            double minimumVisibleWindowEdge,
+            Action<string> logInfo,
+            Action<string> logWarn)
+        {
+            var effectiveState = windowState == WindowState.Minimized
+                ? LastNonMinimizedWindowState
+                : windowState;
+
+            if (effectiveState == WindowState.Maximized && _windowLayoutController.IsUsableWindowBounds(restoreBounds))
+            {
+                LastKnownNormalBounds = restoreBounds;
+            }
+            else
+            {
+                TrackCurrentNormalWindowBounds(windowState, currentBounds);
+            }
+
+            var bounds = _windowLayoutController.IsUsableWindowBounds(LastKnownNormalBounds)
+                ? LastKnownNormalBounds
+                : effectiveState == WindowState.Maximized ? restoreBounds : currentBounds;
+
+            var workAreas = _getMonitorWorkAreasDip();
+            if (!_windowLayoutController.TryBuildLayoutSnapshot(
+                    bounds,
+                    effectiveState,
+                    minWidth,
+                    minHeight,
+                    minimumSavedWindowWidth,
+                    minimumSavedWindowHeight,
+                    minimumVisibleWindowEdge,
+                    workAreas,
+                    out var snapshot,
+                    out var failureReason))
+            {
+                logWarn(
+                    $"Window layout save skipped.\nreason='{reason}' mode={mode} bounds={_windowLayoutController.DescribeRect(bounds)} failureReason='{failureReason}' virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}");
+                return;
+            }
+
+            _windowLayoutController.ApplySnapshot(settings, snapshot, mode);
+            _saveSettings(settings);
+
+            logInfo(
+                $"Window layout saved.\nreason='{reason}' mode={mode} bounds={_windowLayoutController.DescribeRect(bounds)} maximized={snapshot.IsMaximized} virtualWorkAreas={_windowLayoutController.BuildVirtualDesktopSummary(workAreas)}");
+        }
+
+        public void ClearSavedLayouts(AppSettings settings)
+        {
+            _windowLayoutController.ClearAllSavedLayouts(settings);
+            _saveSettings(settings);
+        }
+
+        public Rect GetDefaultWindowBounds(
+            double minimumSavedWindowWidth,
+            double minimumSavedWindowHeight,
+            double defaultWindowWidth,
+            double defaultWindowHeight)
+        {
+            return _windowLayoutController.GetDefaultWindowBounds(
+                _getMonitorWorkAreasDip(),
+                minimumSavedWindowWidth,
+                minimumSavedWindowHeight,
+                defaultWindowWidth,
+                defaultWindowHeight);
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary

Refactors `MainWindow.xaml.cs` by extracting focused support and lifecycle surfaces while preserving existing behavior.

This PR extracts:

- diagnostics/cache support composition
- Intel support composition
- board sort/order coordination
- pilot detail pane/window coordination
- EVE session-context display/update coordination
- board population/retry/clear orchestration
- native input lifecycle for clipboard listener and global hotkeys
- window layout restore/save/reset coordination

## Why

`MainWindow.xaml.cs` had grown into a large coordination surface. This refactor reduces its size and responsibility while keeping WPF-bound behavior conservative and test-backed.

Line-count result:

- Before: `3,410` total / `2,926` nonblank lines
- After: `2,711` total / `2,340` nonblank lines
- Reduction: `699` total / `586` nonblank lines

## Validation

- `git status` clean after commits
- `dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"` passed
- `dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"` passed
  - `218/218` tests passing
- `git --no-pager diff --check` passed
- PMG smoke scripts passed during the refactor passes:
  - `.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30 -BoardPopulationTimeoutSeconds 300`
  - `.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke -ResponsivenessSeconds 30`

Smoke coverage included:

- app start/close
- clipboard listener detects copied local and populates board
- Analysis tab reflects board after population
- diagnostics refresh buttons
- Intel live-feed/background-repair toggles
- board grid lines toggle
- responsiveness checks

## Notes / deferred seams

This intentionally stops short of forcing `MainWindow.xaml.cs` below 2,000 lines. The remaining candidates involve more fragile WPF event-boundary behavior, compact-board drag behavior, row interaction event handlers, and raw window message plumbing. Those should be handled separately if still desired.

Refs #54
