### PR TITLE
Update SharpCompress to clear vulnerability check

### DIFF
--- a/PitmastersGrill/PitmastersGrill.csproj
+++ b/PitmastersGrill/PitmastersGrill.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
-    <PackageReference Include="SharpCompress" Version="0.47.3" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
﻿## Summary

Updates SharpCompress from 0.47.3 to 0.48.0 to clear the repository dependency vulnerability check.

## Why

GitHub Actions reported a moderate vulnerability for SharpCompress 0.47.3 during the PR #71 checks. This fix keeps the dependency update separate from the MainWindow refactor.

## Validation

- `.\tools\dependencies\check-dotnet-vulnerabilities.ps1` passed
  - no vulnerable package reports found
- `dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"` passed
- `dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"` passed
  - `206/206` tests passing
- `git --no-pager diff --check` passed

## Notes

This is intentionally separate from the MainWindow refactor PR.

Refs #71
