### PR TITLE
Prepare PMG v1.4.0 release metadata

### DIFF
--- a/PMG-FEATURES.md
+++ b/PMG-FEATURES.md
@@ -443,7 +443,7 @@ PMG is in General Release.
 
 Current release:
 
-- **Pitmasters Grill v1.3.0**
+- **Pitmasters Grill v1.4.0**
 - General Release
 - Windows desktop application
 

--- a/Patch Notes/General-Release_1-4-0.md
+++ b/Patch Notes/General-Release_1-4-0.md
@@ -1,0 +1,50 @@
+# v1.4.0 Patch Notes
+
+## Overview
+
+v1.4.0 is a MainWindow cleanup, supportability, and release-hardening update for Pitmaster's Grill.
+
+This release completes the staged MainWindow responsibility extraction work, finishes the MainWindow under-2,000-line gate, reduces shell/layout glue in the WPF host, and rolls in the SharpCompress dependency update needed to clear vulnerability checks cleanly.
+
+## Added
+
+### MainWindow Structure Hardening
+
+- Completed the MainWindow responsibility extraction work that was tracked for issue `#54`.
+- Added focused board-layout and board-column settings surfaces to reduce MainWindow-owned layout orchestration.
+- Added focused shell/compact-window surface wiring to reduce MainWindow-owned window-state and compact-mode coordination.
+- Added additional presenter/controller boundaries around Intel, diagnostics, board analysis, board sorting, session context, native input routing, and pilot detail support.
+
+### Validation and Release Hardening
+
+- Added release-ready validation coverage for the final MainWindow reduction pass with build, test, vulnerability, diff-check, and smoke verification.
+- Updated SharpCompress to `0.48.0`, clearing the dependency vulnerability check that previously needed follow-up.
+
+## Changed
+
+- `MainWindow.xaml.cs` is now under `2,000` total lines.
+- MainWindow now acts more as orchestration glue and less as the direct owner of diagnostics, Intel, board layout, shell behavior, and analysis presentation logic.
+- Wrapper-only shell/layout/detail/support methods were collapsed so existing extracted services are called more directly.
+
+## Fixed / Improved
+
+- Reduced MainWindow maintenance risk by removing leftover passthrough glue that no longer carried independent behavior.
+- Improved reviewability of remaining MainWindow responsibilities by keeping board/detail/Win32 boundaries in place while extracting the lower-risk support surfaces around them.
+- Preserved existing PMG behavior while completing the line-count gate rather than forcing a riskier WPF rewrite.
+
+## Validation
+
+Validated during release preparation with:
+
+- `dotnet build .\PitmastersGrill\PitmastersGrill.csproj`
+- `dotnet test .\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj`
+- `.\tools\dependencies\check-dotnet-vulnerabilities.ps1`
+- `git --no-pager diff --check`
+- `.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -ResponsivenessSeconds 30 -BoardPopulationTimeoutSeconds 300`
+- `.\scripts\Invoke-PmgSmokeTest.ps1 -FullUiSmoke -SkipBoardPopulationSmoke -ResponsivenessSeconds 30`
+
+## Notes for Users
+
+This release is primarily about maintainability, shell cleanup, and release confidence rather than new gameplay-facing capability.
+
+PMG continues to use user-provided input and public EVE data only.

--- a/Patch Notes/readme.md
+++ b/Patch Notes/readme.md
@@ -11,19 +11,19 @@ Use patch notes for version-by-version release history. Keep the main `README.md
 Current General Release:
 
 ```text
-Pitmasters Grill v1.3.0
+Pitmasters Grill v1.4.0
 ```
 
 Release page:
 
 ```text
-https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.3.0
+https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.4.0
 ```
 
 Current release notes:
 
 ```text
-General-Release_1-3-0.md
+General-Release_1-4-0.md
 ```
 
 ---

--- a/PitmastersGrill/PitmastersGrill.csproj
+++ b/PitmastersGrill/PitmastersGrill.csproj
@@ -8,7 +8,7 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
-    <PmgReleaseVersion>1.3.0</PmgReleaseVersion>
+    <PmgReleaseVersion>1.4.0</PmgReleaseVersion>
 
     <Version>$(PmgReleaseVersion)</Version>
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ PMG is now in **General Release**.
 
 ---
 
-Current release: **[Pitmasters Grill v1.3.0](https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.3.0)**
+Current release: **[Pitmasters Grill v1.4.0](https://github.com/SmokeyForged/Pitmasters-Grill/releases/tag/v1.4.0)**
 Full release history: **[GitHub Releases](https://github.com/SmokeyForged/Pitmasters-Grill/releases)**
 
-Repository status on `main`: **1.3.0 general release clarity, supportability, UI polish, and update-awareness improvements are present**. This release improves signal/public-data explanation, release readiness, and safe update awareness. It does **not** add new EVE intel sources, private data access, gameplay automation, or automatic self-install behavior.
+Repository status on `main`: **1.4.0 general release MainWindow cleanup, supportability, shell/layout extraction, and release-hardening improvements are present**. This release completes the staged MainWindow responsibility extraction, brings `MainWindow.xaml.cs` under the 2,000-line gate, and improves maintainability without changing PMG into a different tool. It does **not** add new EVE intel sources, private data access, gameplay automation, or automatic self-install behavior.
 
 ---
 
@@ -123,8 +123,8 @@ New here? Start with:
 - **[Patch Notes](./Patch%20Notes/)**  
   Full release history and version notes.
 
-- **[1.3.0 General Release Notes](./Patch%20Notes/General-Release_1-3-0.md)**
-  Summary of the 1.3.0 clarity, supportability, UI polish, release-readiness, and update-awareness work.
+- **[1.4.0 General Release Notes](./Patch%20Notes/General-Release_1-4-0.md)**
+  Summary of the 1.4.0 MainWindow cleanup, shell/layout extraction, dependency hardening, and release validation work.
 
 - **[Current Feature Snapshot](./PMG-FEATURES.md)**  
   A deeper overview of PMG's current feature set and limitations.


### PR DESCRIPTION
﻿## Summary

Prepares PMG release metadata and current-release documentation for v1.4.0.

This PR includes:

- bumps PMG app release metadata from 1.3.0 to 1.4.0
- adds v1.4.0 general release notes
- updates README current-release/status references
- updates Patch Notes index current-release pointer
- updates PMG-FEATURES current release line

## Why

PR #73 completed the MainWindow under-2,000-line gate for v1.4.0. This follow-up updates release metadata and documentation so the app and repo now identify v1.4.0 as the current release line.

## Validation

- `dotnet build "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill\PitmastersGrill.csproj"` passed
- `dotnet test "C:\Users\gregm\source\repos\Pitmasters-Grill\PitmastersGrill.Tests\PitmastersGrill.Tests.csproj"` passed
  - `222/222` tests passing
- `.\tools\dependencies\check-dotnet-vulnerabilities.ps1` passed
  - no vulnerable package reports found
- `git --no-pager diff --check` passed

## Notes

- Historical v1.3.0 release notes were intentionally preserved.
- Version-comparison tests using v1.3.0 fixtures were intentionally preserved.
- Generated `bin`/`obj`/`artifacts` outputs were excluded from release metadata edits.

Refs #73
