### PR TITLE
Add GitHub Actions draft release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,232 @@
+name: Draft PMG Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to draft, for example 1.4.0"
+        required: true
+        type: string
+      release_kind:
+        description: "Release kind for audit context. This does not calculate the version."
+        required: true
+        default: "minor"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - hotfix
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    name: Build package and create draft release
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Validate release metadata
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $version = "${{ github.event.inputs.version }}".Trim()
+          $releaseKind = "${{ github.event.inputs.release_kind }}".Trim()
+
+          if ($releaseKind -notin @("patch", "minor", "major", "hotfix")) {
+            throw "release_kind must be one of: patch, minor, major, hotfix. Got '$releaseKind'."
+          }
+
+          if ($version -notmatch '^\d+\.\d+\.\d+$') {
+            throw "Version input must be semantic version major.minor.patch. Got '$version'."
+          }
+
+          $projectPath = "PitmastersGrill/PitmastersGrill.csproj"
+          if (-not (Test-Path $projectPath)) {
+            throw "Project file missing: $projectPath"
+          }
+
+          $projectText = Get-Content $projectPath -Raw
+          if ($projectText -notmatch '<PmgReleaseVersion>(?<version>[^<]+)</PmgReleaseVersion>') {
+            throw "PmgReleaseVersion was not found in $projectPath."
+          }
+
+          $projectVersion = $Matches["version"].Trim()
+          if ($projectVersion -ne $version) {
+            throw "Version input '$version' does not match PmgReleaseVersion '$projectVersion'."
+          }
+
+          $tag = "v$version"
+          $title = "Pitmasters Grill $version"
+          $zipName = "PMG_General-Release_v$version.zip"
+          $notesPath = Join-Path "Patch Notes" ("General-Release_{0}.md" -f $version.Replace(".", "-"))
+
+          if (-not (Test-Path $notesPath -PathType Leaf)) {
+            throw "Release notes file missing: $notesPath"
+          }
+
+          $readme = Get-Content "README.md" -Raw
+          if ($readme -notmatch [regex]::Escape($tag)) {
+            throw "README.md does not reference current release tag $tag."
+          }
+
+          $patchNotesIndex = Get-Content (Join-Path "Patch Notes" "readme.md") -Raw
+          if ($patchNotesIndex -notmatch [regex]::Escape($tag)) {
+            throw "Patch Notes/readme.md does not reference current release tag $tag."
+          }
+
+          $releaseDesign = Get-Content "docs/RELEASE-AUTOMATION-DESIGN.md" -Raw
+          if ($releaseDesign -notmatch 'PMG_General-Release_v<major>\.<minor>\.<patch>\.zip') {
+            throw "Canonical release ZIP naming pattern was not found in docs/RELEASE-AUTOMATION-DESIGN.md."
+          }
+
+          "RELEASE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_KIND=$releaseKind" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_TAG=$tag" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_TITLE=$title" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_NOTES_PATH=$notesPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+          Write-Host "Release version: $version"
+          Write-Host "Release kind: $releaseKind"
+          Write-Host "Release tag: $tag"
+          Write-Host "Release title: $title"
+          Write-Host "Release ZIP: $zipName"
+          Write-Host "Release notes: $notesPath"
+
+      - name: Refuse if release already exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          $output = gh release view $env:RELEASE_TAG --repo "${{ github.repository }}" 2>&1
+          $exitCode = $LASTEXITCODE
+
+          if ($exitCode -eq 0) {
+            Write-Host $output
+            throw "Release $env:RELEASE_TAG already exists. Refusing to overwrite or mutate an existing release."
+          }
+
+          Write-Host "No existing release found for $env:RELEASE_TAG. Continuing."
+
+      - name: Restore
+        shell: pwsh
+        run: dotnet restore PitmastersGrill/PitmastersGrill.slnx
+
+      - name: Build
+        shell: pwsh
+        run: dotnet build PitmastersGrill/PitmastersGrill.slnx --configuration Release --no-restore
+
+      - name: Test
+        shell: pwsh
+        run: dotnet test PitmastersGrill.Tests/PitmastersGrill.Tests.csproj --configuration Release --no-build
+
+      - name: Check dependency vulnerabilities
+        shell: pwsh
+        run: ./tools/dependencies/check-dotnet-vulnerabilities.ps1
+
+      - name: Publish win-x64
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $publishPath = Join-Path $env:RUNNER_TEMP "pmg-publish"
+          if (Test-Path $publishPath) {
+            Remove-Item $publishPath -Recurse -Force
+          }
+
+          dotnet publish PitmastersGrill/PitmastersGrill.csproj `
+            --configuration Release `
+            --runtime win-x64 `
+            --self-contained false `
+            --output $publishPath
+
+          if (-not (Test-Path (Join-Path $publishPath "PitmastersGrill.exe")) -and -not (Test-Path (Join-Path $publishPath "PitmastersGrill.dll"))) {
+            throw "Publish output does not contain PitmastersGrill.exe or PitmastersGrill.dll."
+          }
+
+          "PUBLISH_PATH=$publishPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Publish path: $publishPath"
+
+      - name: Package ZIP and checksum
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $releaseRoot = Join-Path $env:GITHUB_WORKSPACE "release-output"
+          if (Test-Path $releaseRoot) {
+            Remove-Item $releaseRoot -Recurse -Force
+          }
+
+          New-Item -ItemType Directory -Force -Path $releaseRoot | Out-Null
+
+          $zipPath = Join-Path $releaseRoot $env:RELEASE_ZIP_NAME
+          $checksumPath = "$zipPath.sha256"
+
+          Compress-Archive -Path (Join-Path $env:PUBLISH_PATH "*") -DestinationPath $zipPath -Force
+
+          $hash = Get-FileHash -Path $zipPath -Algorithm SHA256
+          "$($hash.Hash)  $($env:RELEASE_ZIP_NAME)" | Set-Content -Path $checksumPath -Encoding UTF8
+
+          $summaryPath = Join-Path $releaseRoot "release-package-summary.txt"
+          @(
+            "Version: $env:RELEASE_VERSION"
+            "Release kind: $env:RELEASE_KIND"
+            "Release title: $env:RELEASE_TITLE"
+            "Tag: $env:RELEASE_TAG"
+            "ZIP: $env:RELEASE_ZIP_NAME"
+            "Checksum: $($env:RELEASE_ZIP_NAME).sha256"
+            "SHA256: $($hash.Hash)"
+            "Release notes: $env:RELEASE_NOTES_PATH"
+            "Commit: $env:GITHUB_SHA"
+          ) | Set-Content -Path $summaryPath -Encoding UTF8
+
+          "RELEASE_ROOT=$releaseRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_ZIP_PATH=$zipPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_CHECKSUM_PATH=$checksumPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "RELEASE_SUMMARY_PATH=$summaryPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+          Write-Host "ZIP: $zipPath"
+          Write-Host "Checksum: $checksumPath"
+          Write-Host "SHA256: $($hash.Hash)"
+
+      - name: Upload release artifacts to workflow run
+        uses: actions/upload-artifact@v4
+        with:
+          name: PMG-General-Release-${{ env.RELEASE_VERSION }}
+          path: |
+            release-output/${{ env.RELEASE_ZIP_NAME }}
+            release-output/${{ env.RELEASE_ZIP_NAME }}.sha256
+            release-output/release-package-summary.txt
+          if-no-files-found: error
+
+      - name: Create GitHub draft release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          gh release create $env:RELEASE_TAG `
+            $env:RELEASE_ZIP_PATH `
+            $env:RELEASE_CHECKSUM_PATH `
+            --repo "${{ github.repository }}" `
+            --title $env:RELEASE_TITLE `
+            --notes-file $env:RELEASE_NOTES_PATH `
+            --target $env:GITHUB_SHA `
+            --draft
+
+          Write-Host "Draft release created for $env:RELEASE_TAG."
+          Write-Host "Review the draft in GitHub before publishing."


### PR DESCRIPTION
﻿## Summary

Add a GitHub Actions workflow that creates a validated PMG draft release from GitHub-side automation.

The goal is to move release creation and draft handling into GitHub Actions while keeping final publication manual and operator-controlled.

## Why

The current release path uses local helper scripts for readiness, package preparation, and draft-release creation. The helpers are useful for validation and package preparation, but the actual GitHub release/draft path should be GitHub-side so the release artifact and draft are produced from repo state rather than local machine state.

Target model:

- GitHub Actions performs the repeatable release work.
- GitHub Actions creates a draft release only.
- The operator reviews the draft and manually publishes.

## Scope

Add a manual GitHub Actions workflow for draft release creation.

The workflow should:

- use `workflow_dispatch`
- require a version input, such as `1.4.0`
- verify the input version matches `PmgReleaseVersion`
- verify release notes exist for the version
- verify README/current-release references match the version
- run build/test validation
- run dependency vulnerability validation
- publish PMG for `win-x64`
- create canonical ZIP: `PMG_General-Release_v<version>.zip`
- generate SHA256 checksum
- upload ZIP/checksum as workflow artifacts
- create a GitHub draft release
- attach the ZIP and checksum to the draft
- refuse to proceed if the release already exists
- stop before publishing

## Non-goals

- Do not automatically publish the release.
- Do not silently overwrite an existing release.
- Do not silently overwrite existing assets.
- Do not remove local helper scripts in this issue.
- Do not change PMG runtime behavior.
- Do not add self-updater install behavior.

## Acceptance criteria

- A new GitHub Actions workflow exists under `.github/workflows/`.
- The workflow can be manually run from the Actions tab.
- The workflow requires a version input.
- The workflow validates `PmgReleaseVersion`.
- The workflow validates the release notes and README current-release reference.
- The workflow builds and tests PMG.
- The workflow runs the dependency vulnerability check.
- The workflow publishes PMG release output.
- The workflow creates the canonical release ZIP and SHA256 checksum.
- The workflow uploads ZIP/checksum as workflow artifacts.
- The workflow creates a GitHub draft release only.
- The workflow does not publish the release.
- The workflow is documented enough for future release use.

## Validation expectations

- Workflow PR checks pass.
- A manual workflow run for v1.4.0 succeeds.
- Draft release metadata matches:
  - title: `Pitmasters Grill 1.4.0`
  - tag: `v1.4.0`
  - asset: `PMG_General-Release_v1.4.0.zip`
  - checksum asset present
- Final publish remains manual.
